### PR TITLE
Safely Expose Auth0 Public Credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 NUXT_PUBLIC_COMMUNITY_NAME=
 
 # Optional: Auth0 Configuration (enables authentication)
-NUXT_AUTH0_DOMAIN=
 NUXT_AUTH0_SECRET=
-NUXT_AUTH0_CLIENT_ID=
 NUXT_AUTH0_REDIRECT_URI=
+NUXT_PUBLIC_AUTH0_CLIENT_ID=
+NUXT_PUBLIC_AUTH0_DOMAIN=
 
 # Service Availability Flags (set to 'true' to enable each service)
 NUXT_PUBLIC_SUPERSET_ENABLED=

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,12 +22,12 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
-    auth0Domain: "",
-    auth0ClientId: "",
     auth0RedirectUri: "",
 
     public: {
       communityName: "demo",
+      auth0Domain: "",
+      auth0ClientId: "",
       // Service availability flags
       supersetEnabled: false,
       windmillEnabled: false,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,8 +6,8 @@ const config = useRuntimeConfig();
 
 const communityName = config.public.communityName;
 
-const domain = config.auth0Domain;
-const clientId = config.auth0ClientId;
+const domain = config.public.auth0Domain;
+const clientId = config.public.auth0ClientId;
 
 // Auth state
 const isAuthenticated = ref(false);


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).

## Goal
Following up on my discovery here, https://github.com/ConservationMetrics/gc-landing-page/issues/13#issuecomment-3102249663, this PR moves `CLIENT_ID` and `DOMAIN` to public as we run an SPA. 

## Screenshots
<img width="1470" height="876" alt="Screenshot 2025-07-22 at 14 43 41" src="https://github.com/user-attachments/assets/64d9618a-29d0-42a3-b3f6-7c0ce32e40a7" />


## What I changed
- Moved the relevant auth0 values to the public object in Nuxt config. 
- In `index.vue`, prefixed them with public.

## What I'm not doing here
N/A
