### PR TITLE
Adjust RBAC definitions based on latest work in gc-explorer 

### DIFF
--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -1,5 +1,6 @@
 import { defineNuxtRouteMiddleware, navigateTo } from "#imports";
 import type { User } from "~/types/types";
+import { Role } from "~/types/types";
 import { createError } from "h3";
 // Following example: https://github.com/atinux/atidone/blob/main/app/middleware/auth.ts
 export default defineNuxtRouteMiddleware(async (to) => {
@@ -39,9 +40,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   // Admin route protection
   if (loggedIn.value && to.path.startsWith("/admin")) {
-    const hasAdminRole = (user.value as User)?.roles?.some((role: { name: string }) => role.name === "Admin");
+    const userRole = (user.value as User)?.userRole;
     
-    if (!hasAdminRole) {
+    if (!userRole || userRole < Role.Admin) {
       throw createError({
         statusCode: 403,
         statusMessage: "Access denied. Admin privileges required.",

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,6 +1,6 @@
 export const Role = {
-    Public: 0, // Not signed in, no permissions
-    Viewer: 1, // Signed in but no special permissions
+    SignedIn: 0, // Signed in but no elevated access
+    Guest: 1, // Signed in with guest permissions
     Member: 2, // Signed in with member permissions
     Admin: 3, // Signed in with admin permissions
   } as const;


### PR DESCRIPTION
## Goal
Adjust RBAC Definitions based on latest work in gc-explorer and align roles. Closes #32 

## Screenshots
<img width="1470" height="956" alt="Screenshot 2025-10-27 at 14 32 02" src="https://github.com/user-attachments/assets/0fad90a1-6e57-47ea-8ea7-1decd0a50eb5" />
<img width="1470" height="843" alt="Screenshot 2025-10-27 at 14 30 56" src="https://github.com/user-attachments/assets/10b15141-ff06-420a-94c5-a6cda9b030d2" />
<img width="1470" height="843" alt="Screenshot 2025-10-27 at 14 26 10" src="https://github.com/user-attachments/assets/b474d164-911f-4538-ab30-f41b43c865d6" />

## What I changed
- Updated role definitions from `Public/Viewer/Member/Admin` to `SignedIn/Guest/Member/Admin` to match gc-explorer
- Enhanced auth0.get.ts to automatically assign "SignedIn" role to users without roles (mirrors gc-explorer behavior)
- Implemented RBAC visibility controls:
  - User Management: Admin only
  - Windmill: Admin only  
  - Filebrowser: Member and higher
  - Superset: Guest and higher
  - Explorer: SignedIn and higher
- Updated middleware to use numeric role comparison instead of string matching

## What I'm not doing here
- Changing existing Auth0 role names or structure
- Modifying user management functionality
- Updating documentation

## LLM use disclosure
Used LLM to mirror `auth0.get.ts` since it already exists.