### PR TITLE
Fetch auth0 roles once, then apply to users

### DIFF
--- a/server/api/roles.get.ts
+++ b/server/api/roles.get.ts
@@ -1,25 +1,25 @@
 import { fetchAllRoles } from "~/server/utils/auth0Management";
 
 export default defineEventHandler(async () => {
-    try {
-        const roles = await fetchAllRoles();
+  try {
+    const roles = await fetchAllRoles();
 
-        if (roles.length === 0) {
-            throw createError({
-                statusCode: 500,
-                statusMessage: "Failed to fetch roles from Auth0",
-            });
-        }
-
-        return {
-            success: true,
-            roles,
-        };
-    } catch (error) {
-        console.error("🔍 Error fetching roles:", error);
-        throw createError({
-            statusCode: 500,
-            statusMessage: "Internal server error",
-        });
+    if (roles.length === 0) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to fetch roles from Auth0",
+      });
     }
+
+    return {
+      success: true,
+      roles,
+    };
+  } catch (error) {
+    console.error("🔍 Error fetching roles:", error);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal server error",
+    });
+  }
 });

--- a/server/api/users.get.ts
+++ b/server/api/users.get.ts
@@ -1,115 +1,110 @@
 import { useRuntimeConfig } from "#imports";
-import { getManagementApiToken, fetchUserRoles } from "~/server/utils/auth0Management";
+import {
+  getManagementApiToken,
+  fetchAllRoles,
+  buildUserRolesMap,
+} from "~/server/utils/auth0Management";
 import type { UserManagementUser, Auth0ManagementUser } from "~/types/types";
 
 export default defineEventHandler(async (event) => {
-    try {
-        
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) {
-            throw createError({
-                statusCode: 500,
-                statusMessage: "Auth0 configuration missing",
-            });
-        }
+    if (!oauth?.auth0?.domain) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Auth0 configuration missing",
+      });
+    }
 
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            throw createError({
-                statusCode: 500,
-                statusMessage: "Failed to get Management API access token",
-            });
-        }
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to get Management API access token",
+      });
+    }
 
-        // Get query parameters for pagination
-        const query = getQuery(event);
-        const page = parseInt(query.page as string) || 0;
-        const perPage = parseInt(query.per_page as string) || 50;
-        const search = query.search as string;
+    // Get query parameters for pagination
+    const query = getQuery(event);
+    const page = parseInt(query.page as string) || 0;
+    const perPage = parseInt(query.per_page as string) || 50;
+    const search = query.search as string;
 
-        // Build the users API URL with pagination
-        let usersUrl = `https://${oauth.auth0.domain}/api/v2/users?page=${page}&per_page=${perPage}&include_totals=true`;
+    // Build the users API URL with pagination
+    let usersUrl = `https://${oauth.auth0.domain}/api/v2/users?page=${page}&per_page=${perPage}&include_totals=true`;
 
-        if (search) {
-            usersUrl += `&q=email:*${encodeURIComponent(search)}*`;
-        }
+    if (search) {
+      usersUrl += `&q=email:*${encodeURIComponent(search)}*`;
+    }
 
-        // Fetch users from Auth0 Management API
-        const usersResponse = await fetch(usersUrl, {
-            headers: {
-                Authorization: `Bearer ${accessToken}`,
-                "Content-Type": "application/json",
-            },
-        });
+    // Fetch users from Auth0 Management API
+    const usersResponse = await fetch(usersUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
 
-        if (!usersResponse.ok) {
-            const errorText = await usersResponse.text();
-            console.error(
-                "🔍 Failed to fetch users from Management API. Status:",
-                usersResponse.status,
-            );
-            console.error("🔍 Error response:", errorText);
-            throw createError({
-                statusCode: usersResponse.status,
-                statusMessage: "Failed to fetch users from Auth0",
-            });
-        }
+    if (!usersResponse.ok) {
+      const errorText = await usersResponse.text();
+      console.error(
+        "🔍 Failed to fetch users from Management API. Status:",
+        usersResponse.status,
+      );
+      console.error("🔍 Error response:", errorText);
+      throw createError({
+        statusCode: usersResponse.status,
+        statusMessage: "Failed to fetch users from Auth0",
+      });
+    }
 
-        const usersData = await usersResponse.json();
+    const usersData = await usersResponse.json();
 
-        // Fetch roles for each user with batching to avoid rate limits
-        // Process users in batches of 10 with a small delay between batches
-        const batchSize = 10;
-        const batchDelay = 100; // 100ms delay between batches
-        const usersWithRoles: UserManagementUser[] = [];
+    // Fetch all roles and build a user->roles map
+    const allRoles = await fetchAllRoles();
+    const userRolesMap = await buildUserRolesMap(allRoles);
 
-        for (let i = 0; i < usersData.users.length; i += batchSize) {
-            const batch = usersData.users.slice(i, i + batchSize) as Auth0ManagementUser[];
-            const batchResults = await Promise.all(
-                batch.map(async (user: Auth0ManagementUser): Promise<UserManagementUser> => {
-                    const roles = await fetchUserRoles(user.user_id);
+    // Map users with their roles from the pre-built map
+    const usersWithRoles: UserManagementUser[] = usersData.users.map(
+      (user: Auth0ManagementUser): UserManagementUser => {
+        const roles = userRolesMap.get(user.user_id) || [];
 
-                    // Check if user is approved (has app_metadata.approved = "true")
-                    const isApproved = user.app_metadata?.approved === "true" || user.app_metadata?.approved === true;
-
-                    return {
-                        id: user.user_id,
-                        email: user.email,
-                        name: user.name ?? "",
-                        nickname: user.nickname ?? "",
-                        picture: user.picture ?? "",
-                        created_at: user.created_at,
-                        last_login: user.last_login ?? "",
-                        logins_count: user.logins_count ?? 0,
-                        roles,
-                        isApproved,
-                        app_metadata: user.app_metadata ?? {},
-                        user_metadata: user.user_metadata ?? {},
-                    };
-                }),
-            );
-            usersWithRoles.push(...batchResults);
-
-            // Add delay between batches (except for the last batch)
-            if (i + batchSize < usersData.users.length) {
-                await new Promise((resolve) => setTimeout(resolve, batchDelay));
-            }
-        }
+        // Check if user is approved (has app_metadata.approved = "true")
+        const isApproved =
+          user.app_metadata?.approved === "true" ||
+          user.app_metadata?.approved === true;
 
         return {
-            success: true,
-            users: usersWithRoles,
-            total: usersData.total,
-            page,
-            per_page: perPage,
+          id: user.user_id,
+          email: user.email,
+          name: user.name ?? "",
+          nickname: user.nickname ?? "",
+          picture: user.picture ?? "",
+          created_at: user.created_at,
+          last_login: user.last_login ?? "",
+          logins_count: user.logins_count ?? 0,
+          roles,
+          isApproved,
+          app_metadata: user.app_metadata ?? {},
+          user_metadata: user.user_metadata ?? {},
         };
-    } catch (error) {
-        console.error("🔍 Error fetching users:", error);
-        throw createError({
-            statusCode: 500,
-            statusMessage: "Internal server error",
-        });
-    }
+      },
+    );
+
+    return {
+      success: true,
+      users: usersWithRoles,
+      total: usersData.total,
+      page,
+      per_page: perPage,
+    };
+  } catch (error) {
+    console.error("🔍 Error fetching users:", error);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal server error",
+    });
+  }
 });

--- a/server/utils/auth0Management.ts
+++ b/server/utils/auth0Management.ts
@@ -9,453 +9,532 @@ let managementTokenCache: { token: string; expiresAt: number } | null = null;
  * Gets or generates a Management API access token for Auth0
  * Uses client credentials flow to obtain a token for API v2 access
  * Implements token caching to avoid unnecessary API calls
- * 
+ *
  * @returns {Promise<string | null>} The access token string, or null if failed
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const getManagementApiToken = async (): Promise<string | null> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (
-            !oauth?.auth0?.clientId ||
-            !oauth?.auth0?.clientSecret ||
-            !oauth?.auth0?.domain
-        ) {
-            console.error("🔍 Auth0 Management API configuration missing");
-            return null;
-        }
-
-        // Check if we have a valid cached token
-        if (managementTokenCache && managementTokenCache.expiresAt > Date.now()) {
-            return managementTokenCache.token;
-        }
-
-        // Generate new access token
-        const tokenResponse = await fetch(
-            `https://${oauth.auth0.domain}/oauth/token`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                },
-                body: new URLSearchParams({
-                    grant_type: "client_credentials",
-                    client_id: oauth.auth0.clientId,
-                    client_secret: oauth.auth0.clientSecret,
-                    audience: `https://${oauth.auth0.domain}/api/v2/`,
-                }),
-            },
-        );
-
-        if (!tokenResponse.ok) {
-            const errorText = await tokenResponse.text();
-            console.error(
-                "🔍 Failed to generate Management API token. Status:",
-                tokenResponse.status,
-            );
-            console.error("🔍 Error response:", errorText);
-            return null;
-        }
-
-        const tokenData = await tokenResponse.json();
-        const accessToken = tokenData.access_token;
-        const expiresIn = tokenData.expires_in || 86400; // Default to 24 hours
-
-        // Cache the token with expiration
-        managementTokenCache = {
-            token: accessToken,
-            expiresAt: Date.now() + expiresIn * 1000 - 60000, // Expire 1 minute early for safety
-        };
-        return accessToken;
-    } catch (error) {
-        console.error("🔍 Error generating Management API token:", error);
-        return null;
+    if (
+      !oauth?.auth0?.clientId ||
+      !oauth?.auth0?.clientSecret ||
+      !oauth?.auth0?.domain
+    ) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return null;
     }
+
+    // Check if we have a valid cached token
+    if (managementTokenCache && managementTokenCache.expiresAt > Date.now()) {
+      return managementTokenCache.token;
+    }
+
+    // Generate new access token
+    const tokenResponse = await fetch(
+      `https://${oauth.auth0.domain}/oauth/token`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: oauth.auth0.clientId,
+          client_secret: oauth.auth0.clientSecret,
+          audience: `https://${oauth.auth0.domain}/api/v2/`,
+        }),
+      },
+    );
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text();
+      console.error(
+        "🔍 Failed to generate Management API token. Status:",
+        tokenResponse.status,
+      );
+      console.error("🔍 Error response:", errorText);
+      return null;
+    }
+
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+    const expiresIn = tokenData.expires_in || 86400; // Default to 24 hours
+
+    // Cache the token with expiration
+    managementTokenCache = {
+      token: accessToken,
+      expiresAt: Date.now() + expiresIn * 1000 - 60000, // Expire 1 minute early for safety
+    };
+    return accessToken;
+  } catch (error) {
+    console.error("🔍 Error generating Management API token:", error);
+    return null;
+  }
 };
 
 /**
  * Fetches a user ID by email address from Auth0 Management API
  * Searches for users with the specified email and returns the first match
- * 
+ *
  * @param {string} email - The email address to search for
  * @returns {Promise<string | null>} The user ID if found, null otherwise
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
-export const fetchUserIdByEmail = async (email: string): Promise<string | null> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+export const fetchUserIdByEmail = async (
+  email: string,
+): Promise<string | null> => {
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) {
-            console.error("🔍 Auth0 Management API configuration missing");
-            return null;
-        }
-
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return null;
-        }
-
-        // Fetch user by email
-        const userResponse = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users-by-email?email=${encodeURIComponent(email)}`,
-            {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-            },
-        );
-
-        if (!userResponse.ok) {
-            const errorText = await userResponse.text();
-            console.error(
-                "🔍 Failed to fetch user by email from Management API. Status:",
-                userResponse.status,
-            );
-            console.error("🔍 Error response:", errorText);
-            return null;
-        }
-
-        const usersData = await userResponse.json();
-
-        if (usersData.length === 0) {
-            console.error("🔍 No user found with email:", email);
-            return null;
-        }
-
-        const userId = usersData[0].user_id;
-        return userId;
-    } catch (error) {
-        console.error("🔍 Error fetching user ID by email:", error);
-        return null;
+    if (!oauth?.auth0?.domain) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return null;
     }
+
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return null;
+    }
+
+    // Fetch user by email
+    const userResponse = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users-by-email?email=${encodeURIComponent(email)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!userResponse.ok) {
+      const errorText = await userResponse.text();
+      console.error(
+        "🔍 Failed to fetch user by email from Management API. Status:",
+        userResponse.status,
+      );
+      console.error("🔍 Error response:", errorText);
+      return null;
+    }
+
+    const usersData = await userResponse.json();
+
+    if (usersData.length === 0) {
+      console.error("🔍 No user found with email:", email);
+      return null;
+    }
+
+    const userId = usersData[0].user_id;
+    return userId;
+  } catch (error) {
+    console.error("🔍 Error fetching user ID by email:", error);
+    return null;
+  }
 };
 
 /**
  * Fetches all roles assigned to a specific user from Auth0 Management API
  * Includes retry logic with exponential backoff for rate limiting
- * 
+ *
  * @param {string} userId - The Auth0 user ID to fetch roles for
  * @param {number} retries - Number of retries remaining (default: 3)
  * @returns {Promise<Array<{id: string, name: string, description: string}>>} Array of role objects with id, name, and description
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const fetchUserRoles = async (
-    userId: string,
-    retries: number = 3,
+  userId: string,
+  retries: number = 3,
 ): Promise<Array<{ id: string; name: string; description: string }>> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) {
-            console.error("🔍 Auth0 Management API configuration missing");
-            return [];
-        }
-
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return [];
-        }
-
-        // Fetch user roles using the provided Management API token
-        const rolesResponse = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
-            {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-            },
-        );
-
-        // Handle different response statuses
-        if (rolesResponse.status === 404) {
-            // User has no roles - this is not an error, just return empty array
-            return [];
-        }
-
-        if (rolesResponse.status === 429) {
-            // Rate limited - retry with exponential backoff
-            if (retries > 0) {
-                const delay = Math.pow(2, 4 - retries) * 1000; // 1s, 2s, 4s
-                await new Promise((resolve) => setTimeout(resolve, delay));
-                return fetchUserRoles(userId, retries - 1);
-            } else {
-                console.error(
-                    `🔍 Rate limited when fetching roles for user ${userId} after retries`,
-                );
-                return [];
-            }
-        }
-
-        if (!rolesResponse.ok) {
-            const errorText = await rolesResponse.text();
-            console.error(
-                `🔍 Failed to fetch user roles from Management API for user ${userId}. Status: ${rolesResponse.status}`,
-            );
-            console.error(`🔍 Error response: ${errorText}`);
-            return [];
-        }
-
-        const rolesData = await rolesResponse.json();
-        return rolesData.map(
-            (role: { id: string; name: string; description: string }) => ({
-                id: role.id,
-                name: role.name,
-                description: role.description,
-            }),
-        );
-    } catch (error) {
-        // Retry on network errors
-        if (retries > 0 && error instanceof Error) {
-            const delay = Math.pow(2, 4 - retries) * 1000;
-            await new Promise((resolve) => setTimeout(resolve, delay));
-            return fetchUserRoles(userId, retries - 1);
-        }
-        console.error(`🔍 Error fetching user roles for user ${userId}:`, error);
-        return [];
+    if (!oauth?.auth0?.domain) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return [];
     }
+
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return [];
+    }
+
+    // Fetch user roles using the provided Management API token
+    const rolesResponse = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    // Handle different response statuses
+    if (rolesResponse.status === 404) {
+      // User has no roles - this is not an error, just return empty array
+      return [];
+    }
+
+    if (rolesResponse.status === 429) {
+      // Rate limited - retry with exponential backoff
+      if (retries > 0) {
+        const delay = Math.pow(2, 4 - retries) * 1000; // 1s, 2s, 4s
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return fetchUserRoles(userId, retries - 1);
+      } else {
+        console.error(
+          `🔍 Rate limited when fetching roles for user ${userId} after retries`,
+        );
+        return [];
+      }
+    }
+
+    if (!rolesResponse.ok) {
+      const errorText = await rolesResponse.text();
+      console.error(
+        `🔍 Failed to fetch user roles from Management API for user ${userId}. Status: ${rolesResponse.status}`,
+      );
+      console.error(`🔍 Error response: ${errorText}`);
+      return [];
+    }
+
+    const rolesData = await rolesResponse.json();
+    return rolesData.map(
+      (role: { id: string; name: string; description: string }) => ({
+        id: role.id,
+        name: role.name,
+        description: role.description,
+      }),
+    );
+  } catch (error) {
+    // Retry on network errors
+    if (retries > 0 && error instanceof Error) {
+      const delay = Math.pow(2, 4 - retries) * 1000;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return fetchUserRoles(userId, retries - 1);
+    }
+    console.error(`🔍 Error fetching user roles for user ${userId}:`, error);
+    return [];
+  }
 };
 
 /**
  * Fetches all available roles from Auth0 Management API
- * 
+ *
  * @returns {Promise<Array<{id: string, name: string, description: string}>>} Array of all role objects with id, name, and description
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
-export const fetchAllRoles = async (): Promise<Array<{ id: string; name: string; description: string }>> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+export const fetchAllRoles = async (): Promise<
+  Array<{ id: string; name: string; description: string }>
+> => {
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) {
-            console.error("🔍 Auth0 Management API configuration missing");
-            return [];
-        }
-
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return [];
-        }
-
-        // Fetch all roles from Auth0 Management API
-        const rolesResponse = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/roles`,
-            {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-            },
-        );
-
-        if (!rolesResponse.ok) {
-            const errorText = await rolesResponse.text();
-            console.error(
-                "🔍 Failed to fetch roles from Management API. Status:",
-                rolesResponse.status,
-            );
-            console.error("🔍 Error response:", errorText);
-            return [];
-        }
-
-        const rolesData = await rolesResponse.json();
-        return rolesData.map((role: { id: string; name: string; description: string }) => ({
-            id: role.id,
-            name: role.name,
-            description: role.description,
-        }));
-    } catch (error) {
-        console.error("🔍 Error fetching roles:", error);
-        return [];
+    if (!oauth?.auth0?.domain) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return [];
     }
+
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return [];
+    }
+
+    // Fetch all roles from Auth0 Management API
+    const rolesResponse = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/roles`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!rolesResponse.ok) {
+      const errorText = await rolesResponse.text();
+      console.error(
+        "🔍 Failed to fetch roles from Management API. Status:",
+        rolesResponse.status,
+      );
+      console.error("🔍 Error response:", errorText);
+      return [];
+    }
+
+    const rolesData = await rolesResponse.json();
+    return rolesData.map(
+      (role: { id: string; name: string; description: string }) => ({
+        id: role.id,
+        name: role.name,
+        description: role.description,
+      }),
+    );
+  } catch (error) {
+    console.error("🔍 Error fetching roles:", error);
+    return [];
+  }
+};
+
+/**
+ * Builds a map of user IDs to their assigned roles by fetching users per role
+ *
+ * @param {Array<{id: string, name: string, description: string}>} roles - Array of all roles
+ * @returns {Promise<Map<string, Array<{id: string, name: string, description: string}>>>} Map of userId -> roles
+ */
+export const buildUserRolesMap = async (
+  roles: Array<{ id: string; name: string; description: string }>,
+): Promise<
+  Map<string, Array<{ id: string; name: string; description: string }>>
+> => {
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
+
+    if (!oauth?.auth0?.domain) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return new Map();
+    }
+
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return new Map();
+    }
+
+    const userRolesMap = new Map<
+      string,
+      Array<{ id: string; name: string; description: string }>
+    >();
+
+    // Fetch users for each role in parallel
+    await Promise.all(
+      roles.map(async (role) => {
+        try {
+          const response = await fetch(
+            `https://${oauth.auth0.domain}/api/v2/roles/${role.id}/users`,
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/json",
+              },
+            },
+          );
+
+          if (response.ok) {
+            const usersWithRole = await response.json();
+
+            // Add this role to each user in the map
+            for (const user of usersWithRole) {
+              const userId = user.user_id;
+              if (!userRolesMap.has(userId)) {
+                userRolesMap.set(userId, []);
+              }
+              userRolesMap.get(userId)!.push(role);
+            }
+          }
+        } catch (error) {
+          console.error(
+            `🔍 Error fetching users for role ${role.name}:`,
+            error,
+          );
+        }
+      }),
+    );
+
+    return userRolesMap;
+  } catch (error) {
+    console.error("🔍 Error building user roles map:", error);
+    return new Map();
+  }
 };
 
 /**
  * Gets the current user's role IDs from Auth0 Management API
  * Returns only the role IDs, not the full role objects
- * 
+ *
  * @param {string} userId - The Auth0 user ID to get roles for
  * @returns {Promise<string[]>} Array of role IDs assigned to the user
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const getCurrentUserRoles = async (
-    userId: string,
+  userId: string,
 ): Promise<string[]> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) {
-            console.error("🔍 Auth0 Management API configuration missing");
-            return [];
-        }
-
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return [];
-        }
-
-        const rolesResponse = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
-            {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-            },
-        );
-
-        if (!rolesResponse.ok) {
-            console.error("🔍 Failed to fetch current user roles");
-            return [];
-        }
-
-        const rolesData = await rolesResponse.json();
-        return rolesData.map((role: { id: string }) => role.id);
-    } catch (error) {
-        console.error("🔍 Error fetching current user roles:", error);
-        return [];
+    if (!oauth?.auth0?.domain) {
+      console.error("🔍 Auth0 Management API configuration missing");
+      return [];
     }
+
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return [];
+    }
+
+    const rolesResponse = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!rolesResponse.ok) {
+      console.error("🔍 Failed to fetch current user roles");
+      return [];
+    }
+
+    const rolesData = await rolesResponse.json();
+    return rolesData.map((role: { id: string }) => role.id);
+  } catch (error) {
+    console.error("🔍 Error fetching current user roles:", error);
+    return [];
+  }
 };
 
 /**
  * Removes all specified roles from a user in Auth0
- * 
+ *
  * @param {string} userId - The Auth0 user ID to remove roles from
  * @param {string[]} roleIds - Array of role IDs to remove from the user
  * @returns {Promise<boolean>} True if successful, false otherwise
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const removeAllUserRoles = async (
-    userId: string,
-    roleIds: string[],
+  userId: string,
+  roleIds: string[],
 ): Promise<boolean> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain || roleIds.length === 0) return true;
+    if (!oauth?.auth0?.domain || roleIds.length === 0) return true;
 
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return false;
-        }
-
-        const response = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
-            {
-                method: "DELETE",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    roles: roleIds,
-                }),
-            },
-        );
-
-        return response.ok;
-    } catch (error) {
-        console.error("🔍 Error removing user roles:", error);
-        return false;
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return false;
     }
+
+    const response = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          roles: roleIds,
+        }),
+      },
+    );
+
+    return response.ok;
+  } catch (error) {
+    console.error("🔍 Error removing user roles:", error);
+    return false;
+  }
 };
 
 /**
  * Assigns specified roles to a user in Auth0
- * 
+ *
  * @param {string} userId - The Auth0 user ID to assign roles to
  * @param {string[]} roleIds - Array of role IDs to assign to the user
  * @returns {Promise<boolean>} True if successful, false otherwise
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const assignUserRoles = async (
-    userId: string,
-    roleIds: string[],
+  userId: string,
+  roleIds: string[],
 ): Promise<boolean> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain || roleIds.length === 0) return true;
+    if (!oauth?.auth0?.domain || roleIds.length === 0) return true;
 
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return false;
-        }
-
-        const response = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    roles: roleIds,
-                }),
-            },
-        );
-
-        return response.ok;
-    } catch (error) {
-        console.error("🔍 Error assigning user roles:", error);
-        return false;
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return false;
     }
+
+    const response = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users/${userId}/roles`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          roles: roleIds,
+        }),
+      },
+    );
+
+    return response.ok;
+  } catch (error) {
+    console.error("🔍 Error assigning user roles:", error);
+    return false;
+  }
 };
 
 /**
  * Updates user metadata in Auth0 using the Management API
- * 
+ *
  * @param {string} userId - The Auth0 user ID to update metadata for
  * @param {any} metadata - The metadata object to update (can include user_metadata, app_metadata, etc.)
  * @returns {Promise<boolean>} True if successful, false otherwise
  * @throws {Error} When Auth0 configuration is missing or API call fails
  */
 export const updateUserMetadata = async (
-    userId: string,
-    metadata: any,
+  userId: string,
+  metadata: any,
 ): Promise<boolean> => {
-    try {
-        const config = useRuntimeConfig();
-        const { oauth } = config;
+  try {
+    const config = useRuntimeConfig();
+    const { oauth } = config;
 
-        if (!oauth?.auth0?.domain) return false;
+    if (!oauth?.auth0?.domain) return false;
 
-        const accessToken = await getManagementApiToken();
-        if (!accessToken) {
-            console.error("🔍 Failed to get Management API access token");
-            return false;
-        }
-
-        const response = await fetch(
-            `https://${oauth.auth0.domain}/api/v2/users/${userId}`,
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(metadata),
-            },
-        );
-
-        return response.ok;
-    } catch (error) {
-        console.error("🔍 Error updating user metadata:", error);
-        return false;
+    const accessToken = await getManagementApiToken();
+    if (!accessToken) {
+      console.error("🔍 Failed to get Management API access token");
+      return false;
     }
+
+    const response = await fetch(
+      `https://${oauth.auth0.domain}/api/v2/users/${userId}`,
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(metadata),
+      },
+    );
+
+    return response.ok;
+  } catch (error) {
+    console.error("🔍 Error updating user metadata:", error);
+    return false;
+  }
 };


### PR DESCRIPTION
## Goal

https://github.com/ConservationMetrics/gc-landing-page/pull/39#pullrequestreview-3472799907. This reduces load time from 9 seconds to ~0.5 seconds or so. Roles are still deterministic.

## What I changed

Optimized user loading by reversing the role-fetching strategy to eliminate the N+1 query pattern.

## What I'm not doing here

I didn't turn off auto-formatting Prettier, since that is our stated convention in the IGP JS repos. So the diff here is kind of ugly.

Look for `buildUserRolesMap`, `fetchAllRoles`.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Guided refactor with Claude Sonnet 4.5 in Cursor.