### PR TITLE
Allow setting domain via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ NUXT_OAUTH_AUTH0_DOMAIN=
 # optional: Community Logo URL
 NUXT_PUBLIC_LOGO_URL=
 
+# optional: Domain (falls back to guardianconnector.net if not set)
+NUXT_PUBLIC_DOMAIN=
+
 # Service Availability Flags (set to 'true' to enable each service)
 NUXT_PUBLIC_SUPERSET_ENABLED=
 NUXT_PUBLIC_FILEBROWSER_ENABLED=

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 
 | Flag | Service | URL Pattern |
 |------|---------|-------------|
-| `NUXT_PUBLIC_SUPERSET_ENABLED` | Superset | `https://superset.{community}.guardianconnector.net` |
-| `NUXT_PUBLIC_WINDMILL_ENABLED` | Windmill | `https://windmill.{community}.guardianconnector.net` |
-| `NUXT_PUBLIC_EXPLORER_ENABLED` | Explorer | `https://explorer.{community}.guardianconnector.net` |
-| `NUXT_PUBLIC_FILEBROWSER_ENABLED` | Filebrowser | `https://files.{community}.guardianconnector.net` |
+| `NUXT_PUBLIC_SUPERSET_ENABLED` | Superset | `https://superset.{community}.{domain}` |
+| `NUXT_PUBLIC_WINDMILL_ENABLED` | Windmill | `https://windmill.{community}.{domain}` |
+| `NUXT_PUBLIC_EXPLORER_ENABLED` | Explorer | `https://explorer.{community}.{domain}` |
+| `NUXT_PUBLIC_FILEBROWSER_ENABLED` | Filebrowser | `https://files.{community}.{domain}` |
 
 ### Multi-Tenant Support
 
@@ -69,12 +69,12 @@ Service URLs are dynamically configured based on `NUXT_PUBLIC_COMMUNITY_NAME`:
 
 ```bash
 # Community: demo
-https://superset.demo.guardianconnector.net
-https://windmill.demo.guardianconnector.net
+https://superset.demo.{domain}
+https://windmill.demo.{domain}
 
 # Community: acme
-https://superset.acme.guardianconnector.net
-https://windmill.acme.guardianconnector.net
+https://superset.acme.{domain}
+https://windmill.acme.{domain}
 ```
 
 ---

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -53,7 +53,7 @@ if (config.public.windmillEnabled) {
   if (hasAdminRole) {
     services.push({
       name: "Windmill",
-      url: `https://windmill.${communityName}.guardianconnector.net`,
+      url: `https://windmill.${communityName}.${domain}`,
     });
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,6 +55,7 @@ export default defineNuxtConfig({
 
     public: {
       communityName: "demo",
+      domain: "guardianconnector.net",
       baseUrl: "http://localhost:8080",
       auth0Enabled: true,
       logoUrl: "",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,6 +13,7 @@ interface User {
 
 const config = useRuntimeConfig();
 const communityName = config.public.communityName;
+const domain = config.public.domain;
 const logoUrl = config.public.logoUrl as string | undefined;
 const { t } = useI18n();
 
@@ -38,7 +39,7 @@ const availableServices = computed(() => {
   if (config.public.explorerEnabled && userRole >= Role.SignedIn) {
     services.push({
       name: "Explorer",
-      url: `https://explorer.${communityName}.guardianconnector.net`,
+      url: `https://explorer.${communityName}.${domain}`,
       icon: "explorer",
       tags: [
         "Maps",
@@ -53,7 +54,7 @@ const availableServices = computed(() => {
   if (config.public.supersetEnabled && userRole >= Role.Guest) {
     services.push({
       name: "Superset",
-      url: `https://superset.${communityName}.guardianconnector.net`,
+      url: `https://superset.${communityName}.${domain}`,
       icon: "superset",
       tags: ["Charts", "Analysis", "Visualizations", "Dashboards"],
     });
@@ -63,7 +64,7 @@ const availableServices = computed(() => {
   if (config.public.windmillEnabled && userRole >= Role.Admin) {
     services.push({
       name: "Windmill",
-      url: `https://windmill.${communityName}.guardianconnector.net`,
+      url: `https://windmill.${communityName}.${domain}`,
       icon: "windmill",
       tags: ["Data Flows", "Scheduled Jobs", "Data Apps"],
     });
@@ -73,7 +74,7 @@ const availableServices = computed(() => {
   if (config.public.filebrowserEnabled && userRole >= Role.Member) {
     services.push({
       name: "Filebrowser",
-      url: `https://files.${communityName}.guardianconnector.net`,
+      url: `https://files.${communityName}.${domain}`,
       icon: "filebrowser",
       tags: ["Files", "Raw Data", "Archives"],
     });


### PR DESCRIPTION
## Goal

Currently the app hard-codes `.guardianconnector.net` for the domain, and thus if you deploy Guardian Connector on a different domain, the links to services are broken.

This PR allows setting `NUXT_PUBLIC_DOMAIN` with a fallback in Nuxt config of `guardianconnector.net` (which will prevent our deployments from breaking if the env var is not set in CapRover).