### PR TITLE
Use `lucide-vue-next` icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ Please review those before submitting pull requests or issues.
 
 Any additional or overriding rules specific to this repository are listed below.
 
+## Icons
+
+Use `lucide-vue-next` for UI icons (Vue components), rather than inline SVGs or other icon libraries.
+
 
 # Contributor License Agreement
 

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -3,6 +3,7 @@ import { useRuntimeConfig } from "#imports";
 import AppHeader from "@/components/shared/AppHeader.vue";
 import HoverTooltip from "@/components/shared/HoverTooltip.vue";
 import ServicesGrid from "@/components/homepage/ServicesGrid.vue";
+import { Lock } from "lucide-vue-next";
 
 const props = defineProps<{
   isAuth0Configured: boolean;
@@ -24,9 +25,7 @@ const { t } = useI18n();
   <div class="flex min-h-screen flex-col bg-white">
     <AppHeader />
 
-    <main
-      class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8"
-    >
+    <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">
           <img
@@ -41,7 +40,11 @@ const { t } = useI18n();
             {{ t("app.welcome") }}
           </h2>
           <p class="mx-auto max-w-3xl text-xl text-gray-600">
-            <i18n-t keypath="app.welcomeSubtitle" tag="span" :values="{ communityName }">
+            <i18n-t
+              keypath="app.welcomeSubtitle"
+              tag="span"
+              :values="{ communityName }"
+            >
               <template #gc>
                 <HoverTooltip :content="t('app.guardianConnectorTooltip')">
                   Guardian Connector
@@ -61,19 +64,7 @@ const { t } = useI18n();
             <div
               class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-600"
             >
-              <svg
-                class="h-8 w-8 text-white"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                />
-              </svg>
+              <Lock class="h-8 w-8 text-white" />
             </div>
             <h3 class="mb-4 text-2xl font-bold text-gray-900">
               {{ t("auth.secureAccessRequired") }}

--- a/components/UserManagement.vue
+++ b/components/UserManagement.vue
@@ -7,10 +7,18 @@ import type {
   UsersResponse,
   RolesResponse,
 } from "~/types/types";
-import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
 import UserEditModal from "@/components/userManagement/UserEditModal.vue";
 import { translateRoleName } from "@/utils/roleTranslations";
-import { navigateTo } from "#imports";
+import { navigateTo, useI18n } from "#imports";
+import { $fetch } from "ofetch";
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Home,
+  Search,
+  XCircle,
+} from "lucide-vue-next";
 const { t } = useI18n();
 
 const users = ref<UserManagementUser[]>([]);
@@ -24,11 +32,6 @@ const currentPage = ref(0);
 const totalUsers = ref(0);
 const perPage = ref(20);
 const imageErrors = ref<Set<string>>(new Set());
-const mobileMenuOpen = ref(false);
-
-const toggleMobileMenu = () => {
-  mobileMenuOpen.value = !mobileMenuOpen.value;
-};
 
 // Computed properties
 const filteredUsers = computed(() => {
@@ -195,7 +198,6 @@ onMounted(async () => {
           >
             {{ t("userManagement.returnToHomepage") }}
           </button>
-          <GlobeLanguagePicker theme="white" variant="icon" />
         </div>
       </div>
     </div>
@@ -208,58 +210,15 @@ onMounted(async () => {
             {{ t("userManagement.title") }}
           </h1>
         </div>
-        <!-- Hamburger Menu Button -->
         <button
-          @click="toggleMobileMenu"
+          type="button"
+          @click="navigateTo('/')"
           class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
-          aria-label="Menu"
+          :aria-label="t('userManagement.returnToHomepage')"
         >
-          <svg
-            class="w-6 h-6 text-gray-700"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
+          <Home class="w-6 h-6 text-gray-700" />
         </button>
       </div>
-    </div>
-
-    <!-- Mobile Menu Dropdown -->
-    <div
-      v-if="mobileMenuOpen"
-      class="sm:hidden mb-4 p-4 bg-white rounded-lg border border-gray-200 shadow-lg"
-    >
-      <button
-        @click="navigateTo('/')"
-        class="w-full flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-gray-50 transition-colors text-left mb-2"
-      >
-        <svg
-          class="w-5 h-5 text-gray-600"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-          />
-        </svg>
-        <span class="text-sm text-gray-700 font-medium">{{
-          t("userManagement.returnToHomepage")
-        }}</span>
-      </button>
-
-      <!-- Language Picker -->
-      <GlobeLanguagePicker variant="mobile" />
     </div>
 
     <!-- Search and Controls -->
@@ -279,19 +238,7 @@ onMounted(async () => {
             <div
               class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
             >
-              <svg
-                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+              <Search class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400" />
             </div>
           </div>
         </div>
@@ -313,17 +260,9 @@ onMounted(async () => {
       class="mb-3 sm:mb-4 p-3 sm:p-4 bg-red-50 border border-red-200 rounded-lg"
     >
       <div class="flex">
-        <svg
+        <XCircle
           class="h-4 w-4 sm:h-5 sm:w-5 text-red-400 flex-shrink-0 mt-0.5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        />
         <div class="ml-2 sm:ml-3">
           <p class="text-xs sm:text-sm text-red-800">{{ error }}</p>
         </div>
@@ -335,17 +274,9 @@ onMounted(async () => {
       class="mb-3 sm:mb-4 p-3 sm:p-4 bg-green-50 border border-green-200 rounded-lg"
     >
       <div class="flex">
-        <svg
+        <CheckCircle2
           class="h-4 w-4 sm:h-5 sm:w-5 text-green-400 flex-shrink-0 mt-0.5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        />
         <div class="ml-2 sm:ml-3">
           <p class="text-xs sm:text-sm text-green-800">{{ success }}</p>
         </div>
@@ -530,13 +461,7 @@ onMounted(async () => {
                 class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Previous</span>
-                <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fill-rule="evenodd"
-                    d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
+                <ChevronLeft class="h-5 w-5" />
               </button>
               <button
                 v-for="page in Math.min(5, totalPages)"
@@ -557,13 +482,7 @@ onMounted(async () => {
                 class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Next</span>
-                <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fill-rule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
+                <ChevronRight class="h-5 w-5" />
               </button>
             </nav>
           </div>

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
-import { useRuntimeConfig, useUserSession } from "#imports";
+import { useI18n, useRuntimeConfig, useUserSession } from "#imports";
+import { Smile } from "lucide-vue-next";
 import { Role, type User } from "~/types/types";
 
 const config = useRuntimeConfig();
@@ -187,19 +188,7 @@ const translateTag = (tag: string) => {
         <div
           class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300"
         >
-          <svg
-            class="h-8 w-8 text-gray-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0112 15c-2.34 0-4.47.881-6.08 2.33"
-            />
-          </svg>
+          <Smile class="h-8 w-8 text-gray-500" />
         </div>
         <h3 class="mb-2 text-xl font-semibold text-gray-900">
           {{ t("services.noServicesAvailable") }}

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
-import { useUserSession, useRuntimeConfig } from "#imports";
+import { useI18n, useRuntimeConfig, useUserSession } from "#imports";
 import { computed, ref } from "vue";
 import { Role } from "~/types/types";
 import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
 import { translateRoleName } from "@/utils/roleTranslations";
 import { useAuthActions } from "@/composables/useAuth";
-import { Users } from "lucide-vue-next";
+import {
+  BadgeCheck,
+  Layers,
+  LogOut,
+  Menu,
+  User as UserIcon,
+  Users,
+} from "lucide-vue-next";
 
 interface User {
   auth0: string;
@@ -45,16 +52,11 @@ const { login, logout } = useAuthActions();
       <!-- Left: Guardian Connector Logo -->
       <NuxtLink to="/" class="flex items-center">
         <div
-          class="w-10 h-10 bg-gradient-to-r from-green-400 to-green-500 rounded-lg flex items-center justify-center"
+          class="w-10 h-10 bg-gradient-to-r from-purple-400 to-purple-500 rounded-lg flex items-center justify-center"
         >
-          <!-- Guardian Connector logo (X symbol) -->
-          <svg
-            class="w-6 h-6 text-white"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
-          </svg>
+          <!-- Guardian Connector placeholder icon -->
+          <!-- TODO: Replace with actual logo when available -->
+          <Layers class="w-6 h-6 text-white" />
         </div>
         <div class="rounded-lg px-4 py-2">
           <h1 class="text-lg max-[1200px]:text-xs font-bold">
@@ -164,7 +166,7 @@ const { login, logout } = useAuthActions();
           </div>
         </div>
 
-        <!-- Language Picker (Globe Icon) -->
+        <!-- Language Picker -->
         <div class="relative group">
           <GlobeLanguagePicker theme="white" variant="icon" />
           <!-- Tooltip -->
@@ -184,13 +186,7 @@ const { login, logout } = useAuthActions();
         <div
           class="w-10 h-10 bg-gradient-to-r from-green-400 to-green-500 rounded-lg flex items-center justify-center"
         >
-          <svg
-            class="w-6 h-6 text-white"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
-          </svg>
+          <Layers class="w-6 h-6 text-white" />
         </div>
         <div class="rounded-lg px-2">
           <h1 class="text-sm font-bold">Guardian Connector</h1>
@@ -204,30 +200,10 @@ const { login, logout } = useAuthActions();
           <div
             class="w-10 h-10 rounded-full bg-white border-2 border-green-500 flex items-center justify-center relative"
           >
-            <svg
-              class="w-6 h-6 text-green-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-              />
-            </svg>
-            <svg
+            <UserIcon class="w-6 h-6 text-green-500" />
+            <BadgeCheck
               class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white rounded-full"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            />
           </div>
         </div>
 
@@ -237,19 +213,7 @@ const { login, logout } = useAuthActions();
           class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-purple-200 transition-colors"
           aria-label="Menu"
         >
-          <svg
-            class="w-6 h-6 text-gray-700"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
+          <Menu class="w-6 h-6 text-gray-700" />
         </button>
       </div>
     </div>
@@ -265,30 +229,10 @@ const { login, logout } = useAuthActions();
           <div
             class="w-10 h-10 rounded-full bg-white border-2 border-green-500 flex items-center justify-center relative"
           >
-            <svg
-              class="w-6 h-6 text-green-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-              />
-            </svg>
-            <svg
+            <UserIcon class="w-6 h-6 text-green-500" />
+            <BadgeCheck
               class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white rounded-full"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            />
           </div>
           <div>
             <p class="text-sm font-semibold text-gray-900">
@@ -332,19 +276,7 @@ const { login, logout } = useAuthActions();
         "
         class="w-full flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-red-50 transition-colors text-left"
       >
-        <svg
-          class="w-5 h-5 text-red-600"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-          />
-        </svg>
+        <LogOut class="w-5 h-5 text-red-600" />
         <span class="text-sm text-red-600 font-medium">{{
           t("auth.signOut")
         }}</span>

--- a/components/shared/GlobeLanguagePicker.vue
+++ b/components/shared/GlobeLanguagePicker.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import type { SupportedLocale } from "~/types/types";
+import { ChevronDown, Globe } from "lucide-vue-next";
 
 const { locale, locales, setLocale } = useI18n();
 const { t } = useI18n();
@@ -118,25 +119,13 @@ const mobileItemClasses = computed(() => {
             : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2',
         ]"
         @click.stop="dropdownOpen = !dropdownOpen"
-        :title="t('header.languagePicker')"
       >
-        <svg
+        <Globe
           :class="[
             'h-5 w-5',
             theme === 'hero' ? 'text-white' : 'text-gray-600',
           ]"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        />
       </button>
     </div>
     <div v-if="dropdownOpen" :class="dropdownClasses" @click.stop>
@@ -165,39 +154,15 @@ const mobileItemClasses = computed(() => {
       class="w-full flex items-center justify-between space-x-3 hover:bg-purple-50 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
-        <svg
-          class="w-5 h-5 text-gray-600"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        <Globe class="w-5 h-5 text-gray-600" />
         <span class="text-sm text-gray-700 font-medium">{{
           t("header.languagePicker")
         }}</span>
       </div>
-      <svg
+      <ChevronDown
         class="w-4 h-4 text-gray-600 transition-transform"
         :class="{ 'rotate-180': languagePickerOpen }"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M19 9l-7 7-7-7"
-        />
-      </svg>
+      />
     </button>
     <div v-if="languagePickerOpen" class="mt-2 space-y-1">
       <button


### PR DESCRIPTION
## Goal

In the spirit of https://github.com/ConservationMetrics/gc-explorer/pull/408, replace all custom SVGs with `lucide-vue-next` icons.

Plus two minor things: 

- I added a few missing imports like `import { $fetch } from "ofetch";` to resolve lint errors in IDE.
- Removed duplicate `GlobeLanguagePicker` from `UserManagement` component (it's already in the header) 

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None