### PR TITLE
Implement `AppHeader` as default layout

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,6 +2,8 @@
 
 <template>
   <div>
-    <NuxtPage />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </div>
 </template>

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { useRuntimeConfig } from "#imports";
-import AppHeader from "@/components/shared/AppHeader.vue";
 import HoverTooltip from "@/components/shared/HoverTooltip.vue";
 import ServicesGrid from "@/components/homepage/ServicesGrid.vue";
 import { Lock } from "lucide-vue-next";
@@ -23,8 +22,6 @@ const { t } = useI18n();
 
 <template>
   <div class="flex min-h-screen flex-col bg-white">
-    <AppHeader />
-
     <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -3,6 +3,7 @@ import { useI18n, useRuntimeConfig, useUserSession } from "#imports";
 import { computed, ref } from "vue";
 import { Role } from "~/types/types";
 import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
+import HeaderBrand from "@/components/shared/HeaderBrand.vue";
 import { translateRoleName } from "@/utils/roleTranslations";
 import { useAuthActions } from "@/composables/useAuth";
 import {
@@ -50,24 +51,11 @@ const { login, logout } = useAuthActions();
     <!-- Desktop Layout - show above 1000px -->
     <div class="flex max-[1000px]:hidden relative items-end justify-around">
       <!-- Left: Guardian Connector Logo -->
-      <NuxtLink to="/" class="flex items-center">
-        <div
-          class="w-10 h-10 bg-gradient-to-r from-purple-400 to-purple-500 rounded-lg flex items-center justify-center"
-        >
-          <!-- Guardian Connector placeholder icon -->
-          <!-- TODO: Replace with actual logo when available -->
-          <Layers class="w-6 h-6 text-white" />
-        </div>
-        <div class="rounded-lg px-4 py-2">
-          <h1 class="text-lg max-[1200px]:text-xs font-bold">
-            Guardian Connector
-          </h1>
-        </div>
-      </NuxtLink>
+      <HeaderBrand />
 
       <!-- Tab with Community Name -->
       <div
-        class="tab-container flex absolute left-[28%] min-[1109px]:left-[26%] min-[1230px]:left-[25%] -bottom-3 flex-col items-center t-[32%]"
+        class="tab-container flex absolute left-[32%] min-[1109px]:left-[29%] min-[1230px]:left-[27%] -bottom-3 flex-col items-center t-[32%]"
       >
         <NuxtLink to="/" class="tab-trigger active">
           <svg
@@ -147,7 +135,7 @@ const { login, logout } = useAuthActions();
           </button>
         </div>
 
-        <!-- User Management (Gear Icon) -->
+        <!-- User Management -->
         <div
           v-if="isAuth0Configured && loggedIn && isAdmin"
           class="relative group"
@@ -182,16 +170,7 @@ const { login, logout } = useAuthActions();
     <!-- Mobile Layout - show below 1000px -->
     <div class="hidden max-[1000px]:flex items-center justify-between">
       <!-- Left: Guardian Connector Logo -->
-      <NuxtLink to="/" class="flex items-center">
-        <div
-          class="w-10 h-10 bg-gradient-to-r from-green-400 to-green-500 rounded-lg flex items-center justify-center"
-        >
-          <Layers class="w-6 h-6 text-white" />
-        </div>
-        <div class="rounded-lg px-2">
-          <h1 class="text-sm font-bold">Guardian Connector</h1>
-        </div>
-      </NuxtLink>
+      <HeaderBrand />
 
       <!-- Right: User Icon and Hamburger Menu -->
       <div class="flex items-center space-x-2">

--- a/components/shared/HeaderBrand.vue
+++ b/components/shared/HeaderBrand.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Layers } from "lucide-vue-next";
+</script>
+
+<template>
+  <NuxtLink
+    to="/"
+    class="flex max-[1000px]:min-w-0 max-[1000px]:flex-1 items-center gap-3"
+  >
+    <div
+      class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-600"
+    >
+      <Layers class="h-6 w-6 text-white" />
+    </div>
+    <div
+      class="min-w-0 shrink rounded-lg py-2 max-[1000px]:px-2 min-[1001px]:px-4"
+    >
+      <h1
+        class="m-0 font-bold leading-tight max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
+      >
+        Guardian Connector
+      </h1>
+    </div>
+  </NuxtLink>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import AppHeader from "@/components/shared/AppHeader.vue";
+</script>
+
+<template>
+  <div class="min-h-screen flex flex-col bg-white">
+    <AppHeader />
+    <slot></slot>
+  </div>
+</template>

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { useUserSession, navigateTo, createError, useHead } from "#imports";
 import UserManagement from "~/components/UserManagement.vue";
-import AppHeader from "@/components/shared/AppHeader.vue";
 // i18n is auto-imported by @nuxtjs/i18n
 
 const { t } = useI18n();
@@ -38,8 +37,5 @@ useHead({
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-white">
-    <AppHeader />
-    <UserManagement />
-  </div>
+  <UserManagement />
 </template>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -15,6 +15,8 @@ onMounted(() => {
 useHead({
   title: "Guardian Connector: " + t("auth.signIn"),
 });
+
+definePageMeta({ layout: false });
 </script>
 
 <template>


### PR DESCRIPTION
## Goal

Same layout approach and `AppHeader` refactor as https://github.com/ConservationMetrics/gc-explorer/pull/409, only here we are actually defining the AppHeader as a default layout as it used most everywhere. We may want to do the same in GC Explorer eventually.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None