### PR TITLE
Implement 7-day dependency cooldown for pnpm resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,11 @@ Any additional or overriding rules specific to this repository are listed below.
 
 Use `lucide-vue-next` for UI icons (Vue components), rather than inline SVGs or other icon libraries.
 
+## Dependency cooldown policy
+
+New JavaScript package versions must be at least 7 days old before they can be introduced.
+If dependency resolution fails due to package age, wait and retry, or select an older version.
+
 
 # Contributor License Agreement
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Copy package files
-COPY package*.json pnpm-lock.yaml ./
+COPY package*.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install all dependencies (including dev dependencies for build)
 RUN pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:20.15.0-slim AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@^10
 
 # Copy package files
 COPY package*.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:20.15.0-slim AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Copy package files
 COPY package*.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,1 @@
-minimumReleaseAge: 10080
+minimumReleaseAge: 10080  # minutes == 7 days


### PR DESCRIPTION

## Goal

Add a 7-day dependency cooldown policy for pnpm so dependency resolution excludes newly published versions and lowers supply-chain risk. Closes #74 

## Screenshots

N/A (infrastructure change)

## What I changed and why

This change adds `pnpm-workspace.yaml` with `minimumReleaseAge: 10080` (7 days) to enforce release-age gating at dependency resolution time. I also updated the Docker build so `pnpm-workspace.yaml` is copied before `pnpm install` in both stages, ensuring the same policy is applied in containerized installs and not only local development.

I added a short contributor-facing policy note in `CONTRIBUTING.md` so developers understand why a dependency may be rejected for being too new and what the expected remediation is (wait or choose an older version).


## What I'm not doing here

- No package upgrades or lockfile refresh for unrelated dependencies.
- No additional trust-policy or exotic-subdependency flags.
- No functional UI or API changes.

## LLM use disclosure

None