### PR TITLE
Fix double-domain service URLs 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,6 @@ NUXT_PUBLIC_LOGO_URL=
 # optional: Login page background image URL or path (falls back to public/background.jpg if not set)
 NUXT_PUBLIC_BACKGROUND_IMAGE=
 
-# optional: Domain (falls back to guardianconnector.net if not set)
-NUXT_PUBLIC_DOMAIN=
-
 # Service Availability Flags (set to 'true' to enable each service)
 NUXT_PUBLIC_SUPERSET_ENABLED=
 NUXT_PUBLIC_FILEBROWSER_ENABLED=

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 
 | Flag | Service | URL Pattern |
 |------|---------|-------------|
-| `NUXT_PUBLIC_SUPERSET_ENABLED` | Superset | `https://superset.{community}.{domain}` |
-| `NUXT_PUBLIC_WINDMILL_ENABLED` | Windmill | `https://windmill.{community}.{domain}` |
-| `NUXT_PUBLIC_EXPLORER_ENABLED` | Explorer | `https://explorer.{community}.{domain}` |
-| `NUXT_PUBLIC_FILEBROWSER_ENABLED` | Filebrowser | `https://files.{community}.{domain}` |
+| `NUXT_PUBLIC_SUPERSET_ENABLED` | Superset | `https://superset.{community}.guardianconnector.net` |
+| `NUXT_PUBLIC_WINDMILL_ENABLED` | Windmill | `https://windmill.{community}.guardianconnector.net` |
+| `NUXT_PUBLIC_EXPLORER_ENABLED` | Explorer | `https://explorer.{community}.guardianconnector.net` |
+| `NUXT_PUBLIC_FILEBROWSER_ENABLED` | Filebrowser | `https://files.{community}.guardianconnector.net` |
 
 ### Multi-Tenant Support
 
@@ -73,12 +73,12 @@ Service URLs are dynamically configured based on `NUXT_PUBLIC_COMMUNITY_NAME`:
 
 ```bash
 # Community: demo
-https://superset.demo.{domain}
-https://windmill.demo.{domain}
+https://superset.demo.guardianconnector.net
+https://windmill.demo.guardianconnector.net
 
 # Community: acme
-https://superset.acme.{domain}
-https://windmill.acme.{domain}
+https://superset.acme.guardianconnector.net
+https://windmill.acme.guardianconnector.net
 ```
 
 ---

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -3,10 +3,10 @@ import { computed } from "vue";
 import { useI18n, useRuntimeConfig, useUserSession } from "#imports";
 import { Smile } from "lucide-vue-next";
 import { Role, type User } from "~/types/types";
+import { buildServiceUrl } from "~/utils/serviceUrl";
 
 const config = useRuntimeConfig();
 const communityName = config.public.communityName;
-const domain = config.public.domain;
 const { t } = useI18n();
 const { user } = useUserSession();
 
@@ -23,7 +23,7 @@ const availableServices = computed(() => {
   if (config.public.explorerEnabled && userRole >= Role.SignedIn) {
     services.push({
       name: "Explorer",
-      url: `https://explorer.${communityName}.${domain}`,
+      url: buildServiceUrl("explorer", communityName),
       icon: "explorer",
       tags: [
         "Maps",
@@ -37,7 +37,7 @@ const availableServices = computed(() => {
   if (config.public.supersetEnabled && userRole >= Role.Guest) {
     services.push({
       name: "Superset",
-      url: `https://superset.${communityName}.${domain}`,
+      url: buildServiceUrl("superset", communityName),
       icon: "superset",
       tags: ["Charts", "Analysis", "Visualizations", "Dashboards"],
     });
@@ -46,7 +46,7 @@ const availableServices = computed(() => {
   if (config.public.windmillEnabled && userRole >= Role.Admin) {
     services.push({
       name: "Windmill",
-      url: `https://windmill.${communityName}.${domain}`,
+      url: buildServiceUrl("windmill", communityName),
       icon: "windmill",
       tags: ["Data Flows", "Scheduled Jobs", "Data Apps"],
     });
@@ -55,7 +55,7 @@ const availableServices = computed(() => {
   if (config.public.filebrowserEnabled && userRole >= Role.Member) {
     services.push({
       name: "Filebrowser",
-      url: `https://files.${communityName}.${domain}`,
+      url: buildServiceUrl("files", communityName),
       icon: "filebrowser",
       tags: ["Files", "Raw Data", "Archives"],
     });

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -53,7 +53,7 @@ if (config.public.windmillEnabled) {
   if (hasAdminRole) {
     services.push({
       name: "Windmill",
-      url: `https://windmill.${communityName}.${domain}`,
+      url: `https://windmill.${communityName}.guardianconnector.net`,
     });
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -52,7 +52,6 @@ export default defineNuxtConfig({
 
     public: {
       communityName: "demo",
-      domain: "guardianconnector.net",
       baseUrl: "http://localhost:8080",
       auth0Enabled: true,
       logoUrl: "",

--- a/utils/serviceUrl.ts
+++ b/utils/serviceUrl.ts
@@ -1,0 +1,15 @@
+export const GC_SERVICE_DOMAIN = "guardianconnector.net";
+
+/**
+ * Builds the HTTPS URL for a GC service subdomain.
+ *
+ * @param {string} service - Service subdomain prefix (e.g. explorer, superset).
+ * @param {string} communityName - Community alias.
+ * @returns {string} Full service URL.
+ */
+export const buildServiceUrl = (
+  service: string,
+  communityName: string,
+): string => {
+  return `https://${service}.${communityName}.${GC_SERVICE_DOMAIN}`;
+};


### PR DESCRIPTION

## Goal

Fix service links on the landing page rendering as `https://<service>.<community>.<community>.guardianconnector.net`.


## Screenshots


## What I changed and why

Service URLs were built from both `NUXT_PUBLIC_COMMUNITY_NAME` and `NUXT_PUBLIC_DOMAIN`, but deploy configs set the latter to the full community root domain (e.g. `<alias>.guardianconnector.net`), duplicating the community segment. I removed the configurable domain and added a small `buildServiceUrl` helper that always uses `guardianconnector.net`, matching deployments like REDACTED where `NUXT_PUBLIC_DOMAIN` was never set.


## What I'm not doing here

No change to `NUXT_PUBLIC_BASE_URL` — it is still used for Auth0 redirect URLs and serves a different purpose.


## LLM use disclosure

