### PR TITLE
Fix mobile text alignment on UserEditModal

### DIFF
--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -129,7 +129,7 @@ const formatDate = (dateString: string) => {
         >
           <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
-              <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
+              <div class="mt-3 sm:mt-0 text-left w-full">
                 <h3
                   class="text-lg leading-6 font-medium text-gray-900 mb-4"
                   id="modal-title"


### PR DESCRIPTION
## Screenshots

Before
<img width="368" height="345" alt="image" src="https://github.com/user-attachments/assets/081b2372-c0a7-4910-8639-6c74d51a0ce0" />

After
<img width="360" height="343" alt="image" src="https://github.com/user-attachments/assets/17fbe837-d1f0-4c9a-ae68-844293335149" />

## What I changed and why

Remove `text-center` on mobile from the modal content wrapper, replacing it with a consistent `text-left` across all breakpoints. The previous Tailwind default was causing form labels and role options to render with odd indentation on small screens.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None