### PR TITLE
Implement dark mode

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,4 +1,15 @@
-<script setup></script>
+<script setup lang="ts">
+import { useHead } from "#imports";
+import { useTheme } from "@/composables/useTheme";
+
+const { isDark } = useTheme();
+
+useHead({
+  htmlAttrs: {
+    class: () => (isDark.value ? "dark" : ""),
+  },
+});
+</script>
 
 <template>
   <div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -43,7 +43,7 @@
 
 .dark .tab-trigger {
   background-color: #5b21b6;
-  color: #f5f5f4;
+  color: #f1f5f9;
 }
 
 .tab-trigger svg {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -43,7 +43,7 @@
 
 .dark .tab-trigger {
   background-color: #5b21b6;
-  color: #f1f5f9;
+  color: #e6e2f3;
 }
 
 .tab-trigger svg {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -16,6 +16,10 @@
   background: rgba(255, 255, 255, 0.3);
 }
 
+.dark ::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 /* Smooth transitions */
 * {
   transition-property:
@@ -37,10 +41,19 @@
   background-color: #fff;
 }
 
+.dark .tab-trigger {
+  background-color: #5b21b6;
+  color: #f5f5f4;
+}
+
 .tab-trigger svg {
   position: absolute;
   height: 40px;
   color: #fff;
+}
+
+.dark .tab-trigger svg {
+  color: #5b21b6;
 }
 
 .tab-trigger .left-curve {

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -22,7 +22,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-white dark:bg-slate-900">
+  <div class="flex min-h-screen flex-col bg-white dark:bg-dusk-900">
     <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">
@@ -34,12 +34,10 @@ const { t } = useI18n();
         </div>
 
         <div class="mb-12 text-center">
-          <h2 class="mb-4 text-4xl font-bold text-gray-900 dark:text-slate-100">
+          <h2 class="mb-4 text-4xl font-bold text-gray-900 dark:text-dusk-100">
             {{ t("app.welcome") }}
           </h2>
-          <p
-            class="mx-auto max-w-3xl text-xl text-gray-600 dark:text-slate-400"
-          >
+          <p class="mx-auto max-w-3xl text-xl text-gray-600 dark:text-dusk-400">
             <i18n-t
               keypath="app.welcomeSubtitle"
               tag="span"
@@ -63,14 +61,14 @@ const { t } = useI18n();
         >
           <div class="absolute inset-0 flex items-center">
             <div
-              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 dark:via-slate-700 to-transparent"
+              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 dark:via-dusk-700 to-transparent"
             ></div>
           </div>
           <div class="relative flex justify-center">
             <div
-              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 dark:from-violet-900/40 dark:to-emerald-900/40 ring-1 ring-gray-200 dark:ring-slate-700"
+              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 dark:from-violet-900/40 dark:to-emerald-900/40 ring-1 ring-gray-200 dark:ring-dusk-700"
             >
-              <Workflow class="h-5 w-5 text-gray-600 dark:text-slate-300" />
+              <Workflow class="h-5 w-5 text-gray-600 dark:text-dusk-300" />
             </div>
           </div>
         </div>
@@ -78,7 +76,7 @@ const { t } = useI18n();
         <DataSourcesGrid v-if="props.shouldShowApp" />
 
         <div v-if="props.shouldShowApp" class="mb-8 mt-8 text-center">
-          <p class="text-sm italic text-gray-600 dark:text-slate-400">
+          <p class="text-sm italic text-gray-600 dark:text-dusk-400">
             {{ t("services.needHelp") }}
             <a
               href="https://docs.guardianconnector.net"

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -22,7 +22,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-white">
+  <div class="flex min-h-screen flex-col bg-white dark:bg-stone-950">
     <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">
@@ -34,10 +34,12 @@ const { t } = useI18n();
         </div>
 
         <div class="mb-12 text-center">
-          <h2 class="mb-4 text-4xl font-bold text-gray-900">
+          <h2 class="mb-4 text-4xl font-bold text-gray-900 dark:text-stone-100">
             {{ t("app.welcome") }}
           </h2>
-          <p class="mx-auto max-w-3xl text-xl text-gray-600">
+          <p
+            class="mx-auto max-w-3xl text-xl text-gray-600 dark:text-stone-400"
+          >
             <i18n-t
               keypath="app.welcomeSubtitle"
               tag="span"
@@ -61,14 +63,14 @@ const { t } = useI18n();
         >
           <div class="absolute inset-0 flex items-center">
             <div
-              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 to-transparent"
+              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 dark:via-stone-700 to-transparent"
             ></div>
           </div>
           <div class="relative flex justify-center">
             <div
-              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 ring-1 ring-gray-200"
+              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 dark:from-violet-900/40 dark:to-emerald-900/40 ring-1 ring-gray-200 dark:ring-stone-700"
             >
-              <Workflow class="h-5 w-5 text-gray-600" />
+              <Workflow class="h-5 w-5 text-gray-600 dark:text-stone-300" />
             </div>
           </div>
         </div>
@@ -76,13 +78,13 @@ const { t } = useI18n();
         <DataSourcesGrid v-if="props.shouldShowApp" />
 
         <div v-if="props.shouldShowApp" class="mb-8 mt-8 text-center">
-          <p class="text-sm italic text-gray-600">
+          <p class="text-sm italic text-gray-600 dark:text-stone-400">
             {{ t("services.needHelp") }}
             <a
               href="https://docs.guardianconnector.net"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-violet-600 underline hover:text-violet-700"
+              class="text-violet-600 dark:text-violet-300 underline hover:text-violet-700 dark:hover:text-violet-200"
             >
               {{ t("services.documentationWebsite") }} </a
             >.

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -22,7 +22,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-white dark:bg-stone-950">
+  <div class="flex min-h-screen flex-col bg-white dark:bg-slate-900">
     <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">
@@ -34,11 +34,11 @@ const { t } = useI18n();
         </div>
 
         <div class="mb-12 text-center">
-          <h2 class="mb-4 text-4xl font-bold text-gray-900 dark:text-stone-100">
+          <h2 class="mb-4 text-4xl font-bold text-gray-900 dark:text-slate-100">
             {{ t("app.welcome") }}
           </h2>
           <p
-            class="mx-auto max-w-3xl text-xl text-gray-600 dark:text-stone-400"
+            class="mx-auto max-w-3xl text-xl text-gray-600 dark:text-slate-400"
           >
             <i18n-t
               keypath="app.welcomeSubtitle"
@@ -63,14 +63,14 @@ const { t } = useI18n();
         >
           <div class="absolute inset-0 flex items-center">
             <div
-              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 dark:via-stone-700 to-transparent"
+              class="h-px w-full bg-gradient-to-r from-transparent via-gray-300 dark:via-slate-700 to-transparent"
             ></div>
           </div>
           <div class="relative flex justify-center">
             <div
-              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 dark:from-violet-900/40 dark:to-emerald-900/40 ring-1 ring-gray-200 dark:ring-stone-700"
+              class="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-violet-100 to-emerald-100 dark:from-violet-900/40 dark:to-emerald-900/40 ring-1 ring-gray-200 dark:ring-slate-700"
             >
-              <Workflow class="h-5 w-5 text-gray-600 dark:text-stone-300" />
+              <Workflow class="h-5 w-5 text-gray-600 dark:text-slate-300" />
             </div>
           </div>
         </div>
@@ -78,7 +78,7 @@ const { t } = useI18n();
         <DataSourcesGrid v-if="props.shouldShowApp" />
 
         <div v-if="props.shouldShowApp" class="mb-8 mt-8 text-center">
-          <p class="text-sm italic text-gray-600 dark:text-stone-400">
+          <p class="text-sm italic text-gray-600 dark:text-slate-400">
             {{ t("services.needHelp") }}
             <a
               href="https://docs.guardianconnector.net"

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -51,7 +51,7 @@ onMounted(() => {
       >
         <GlassCard class="max-w-xl">
           <h1
-            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 dark:text-slate-100 sm:text-3xl sm:leading-tight"
+            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 dark:text-dusk-100 sm:text-3xl sm:leading-tight"
           >
             {{ t("auth.welcomeToGuardianConnector") }}
           </h1>
@@ -60,7 +60,7 @@ onMounted(() => {
             aria-hidden="true"
           ></div>
           <p
-            class="mt-7 text-center text-sm leading-relaxed text-stone-700 dark:text-slate-200 sm:text-[0.95rem]"
+            class="mt-7 text-center text-sm leading-relaxed text-stone-700 dark:text-dusk-200 sm:text-[0.95rem]"
           >
             {{ t("auth.pleaseSignIn") }}
           </p>

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -51,7 +51,7 @@ onMounted(() => {
       >
         <GlassCard class="max-w-xl">
           <h1
-            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 sm:text-3xl sm:leading-tight"
+            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 dark:text-stone-100 sm:text-3xl sm:leading-tight"
           >
             {{ t("auth.welcomeToGuardianConnector") }}
           </h1>
@@ -60,7 +60,7 @@ onMounted(() => {
             aria-hidden="true"
           ></div>
           <p
-            class="mt-7 text-center text-sm leading-relaxed text-stone-700 sm:text-[0.95rem]"
+            class="mt-7 text-center text-sm leading-relaxed text-stone-700 dark:text-stone-200 sm:text-[0.95rem]"
           >
             {{ t("auth.pleaseSignIn") }}
           </p>
@@ -74,7 +74,7 @@ onMounted(() => {
           </button>
           <p
             v-if="props.errorMessage"
-            class="mt-4 text-center text-xs text-red-600"
+            class="mt-4 text-center text-xs text-red-600 dark:text-red-300"
           >
             {{ props.errorMessage }}
           </p>

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -51,7 +51,7 @@ onMounted(() => {
       >
         <GlassCard class="max-w-xl">
           <h1
-            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 dark:text-stone-100 sm:text-3xl sm:leading-tight"
+            class="text-balance text-center text-[1.65rem] font-medium leading-snug tracking-tight text-stone-800 dark:text-slate-100 sm:text-3xl sm:leading-tight"
           >
             {{ t("auth.welcomeToGuardianConnector") }}
           </h1>
@@ -60,7 +60,7 @@ onMounted(() => {
             aria-hidden="true"
           ></div>
           <p
-            class="mt-7 text-center text-sm leading-relaxed text-stone-700 dark:text-stone-200 sm:text-[0.95rem]"
+            class="mt-7 text-center text-sm leading-relaxed text-stone-700 dark:text-slate-200 sm:text-[0.95rem]"
           >
             {{ t("auth.pleaseSignIn") }}
           </p>

--- a/components/SponsorLogos.vue
+++ b/components/SponsorLogos.vue
@@ -4,11 +4,11 @@ const { t } = useI18n();
 
 <template>
   <footer
-    class="flex flex-col items-center gap-5 text-center text-neutral-700 dark:text-slate-300"
+    class="flex flex-col items-center gap-5 text-center text-neutral-700 dark:text-dusk-300"
     data-testid="sponsor-logos"
   >
     <p
-      class="text-base font-semibold tracking-wide text-stone-700 dark:text-slate-200 sm:text-lg"
+      class="text-base font-semibold tracking-wide text-stone-700 dark:text-dusk-200 sm:text-lg"
     >
       {{ t("auth.coCreatedBy") }}
     </p>
@@ -27,7 +27,7 @@ const { t } = useI18n();
       />
     </div>
     <p
-      class="mt-0.5 text-sm italic text-stone-500 dark:text-slate-400 sm:text-[0.95rem]"
+      class="mt-0.5 text-sm italic text-stone-500 dark:text-dusk-400 sm:text-[0.95rem]"
     >
       {{ t("auth.andIndigenousPartners") }}
     </p>

--- a/components/SponsorLogos.vue
+++ b/components/SponsorLogos.vue
@@ -4,10 +4,12 @@ const { t } = useI18n();
 
 <template>
   <footer
-    class="flex flex-col items-center gap-5 text-center text-neutral-700"
+    class="flex flex-col items-center gap-5 text-center text-neutral-700 dark:text-stone-300"
     data-testid="sponsor-logos"
   >
-    <p class="text-base font-semibold tracking-wide text-stone-700 sm:text-lg">
+    <p
+      class="text-base font-semibold tracking-wide text-stone-700 dark:text-stone-200 sm:text-lg"
+    >
       {{ t("auth.coCreatedBy") }}
     </p>
     <div
@@ -24,7 +26,9 @@ const { t } = useI18n();
         class="h-10 w-auto max-w-[min(100%,14rem)] object-contain sm:h-11"
       />
     </div>
-    <p class="mt-0.5 text-sm italic text-stone-500 sm:text-[0.95rem]">
+    <p
+      class="mt-0.5 text-sm italic text-stone-500 dark:text-stone-400 sm:text-[0.95rem]"
+    >
       {{ t("auth.andIndigenousPartners") }}
     </p>
   </footer>

--- a/components/SponsorLogos.vue
+++ b/components/SponsorLogos.vue
@@ -4,11 +4,11 @@ const { t } = useI18n();
 
 <template>
   <footer
-    class="flex flex-col items-center gap-5 text-center text-neutral-700 dark:text-stone-300"
+    class="flex flex-col items-center gap-5 text-center text-neutral-700 dark:text-slate-300"
     data-testid="sponsor-logos"
   >
     <p
-      class="text-base font-semibold tracking-wide text-stone-700 dark:text-stone-200 sm:text-lg"
+      class="text-base font-semibold tracking-wide text-stone-700 dark:text-slate-200 sm:text-lg"
     >
       {{ t("auth.coCreatedBy") }}
     </p>
@@ -27,7 +27,7 @@ const { t } = useI18n();
       />
     </div>
     <p
-      class="mt-0.5 text-sm italic text-stone-500 dark:text-stone-400 sm:text-[0.95rem]"
+      class="mt-0.5 text-sm italic text-stone-500 dark:text-slate-400 sm:text-[0.95rem]"
     >
       {{ t("auth.andIndigenousPartners") }}
     </p>

--- a/components/UserManagement.vue
+++ b/components/UserManagement.vue
@@ -184,18 +184,18 @@ onMounted(async () => {
       <div class="flex justify-between items-start">
         <div>
           <h1
-            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-stone-100 mb-2"
+            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2"
           >
             {{ t("userManagement.title") }}
           </h1>
-          <p class="text-sm sm:text-base text-gray-600 dark:text-stone-400">
+          <p class="text-sm sm:text-base text-gray-600 dark:text-slate-400">
             {{ t("userManagement.subtitle") }}
           </p>
         </div>
         <div class="ml-4 flex items-center gap-3">
           <button
             @click="navigateTo('/')"
-            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 border border-gray-300 dark:border-stone-700 rounded-lg hover:bg-gray-50 dark:hover:bg-stone-800 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-stone-950 transition-colors cursor-pointer"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors cursor-pointer"
           >
             {{ t("userManagement.returnToHomepage") }}
           </button>
@@ -207,24 +207,24 @@ onMounted(async () => {
     <div class="mb-4 sm:hidden">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <h1 class="text-xl font-bold text-gray-900 dark:text-stone-100">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-slate-100">
             {{ t("userManagement.title") }}
           </h1>
         </div>
         <button
           type="button"
           @click="navigateTo('/')"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-stone-800 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
           :aria-label="t('userManagement.returnToHomepage')"
         >
-          <Home class="w-6 h-6 text-gray-700 dark:text-stone-200" />
+          <Home class="w-6 h-6 text-gray-700 dark:text-slate-200" />
         </button>
       </div>
     </div>
 
     <!-- Search and Controls -->
     <div
-      class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 p-3 sm:p-6 mb-4 sm:mb-6"
+      class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-3 sm:p-6 mb-4 sm:mb-6"
     >
       <div class="flex flex-col sm:flex-row gap-4 items-center justify-between">
         <div class="flex-1 max-w-md">
@@ -233,14 +233,14 @@ onMounted(async () => {
               v-model="searchQuery"
               type="text"
               :placeholder="t('userManagement.searchPlaceholder')"
-              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base bg-white dark:bg-stone-800 text-gray-900 dark:text-stone-100 placeholder-gray-400 dark:placeholder-stone-500 border border-gray-300 dark:border-stone-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500 border border-gray-300 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
               @keyup.enter="handleSearch"
             />
             <div
               class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
             >
               <Search
-                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-stone-500"
+                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-slate-500"
               />
             </div>
           </div>
@@ -292,48 +292,48 @@ onMounted(async () => {
 
     <!-- Users Table - Desktop -->
     <div
-      class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 overflow-hidden hidden sm:block"
+      class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 overflow-hidden hidden sm:block"
     >
       <div class="overflow-x-auto">
         <table
-          class="min-w-full divide-y divide-gray-200 dark:divide-stone-700"
+          class="min-w-full divide-y divide-gray-200 dark:divide-slate-700"
         >
-          <thead class="bg-gray-50 dark:bg-stone-800">
+          <thead class="bg-gray-50 dark:bg-slate-700">
             <tr>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.user") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.status") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.roles") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.lastLogin") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.actions") }}
               </th>
             </tr>
           </thead>
           <tbody
-            class="bg-white dark:bg-stone-900 divide-y divide-gray-200 dark:divide-stone-700"
+            class="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700"
           >
             <tr v-if="loading" class="animate-pulse">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-stone-400 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-slate-400 text-sm"
               >
                 {{ t("userManagement.loadingUsers") }}
               </td>
@@ -341,7 +341,7 @@ onMounted(async () => {
             <tr v-else-if="filteredUsers.length === 0">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-stone-400 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-slate-400 text-sm"
               >
                 {{ t("userManagement.noUsersFound") }}
               </td>
@@ -350,7 +350,7 @@ onMounted(async () => {
               v-else
               v-for="user in filteredUsers"
               :key="user.id"
-              class="hover:bg-gray-50 dark:hover:bg-stone-800"
+              class="hover:bg-gray-50 dark:hover:bg-slate-700"
             >
               <td class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap">
                 <div class="flex items-center">
@@ -379,12 +379,12 @@ onMounted(async () => {
                   </div>
                   <div class="ml-2 sm:ml-4">
                     <div
-                      class="text-xs sm:text-sm font-medium text-gray-900 dark:text-stone-100"
+                      class="text-xs sm:text-sm font-medium text-gray-900 dark:text-slate-100"
                     >
                       {{ user.name || user.nickname || "Unknown" }}
                     </div>
                     <div
-                      class="text-xs sm:text-sm text-gray-500 dark:text-stone-400"
+                      class="text-xs sm:text-sm text-gray-500 dark:text-slate-400"
                     >
                       {{ user.email }}
                     </div>
@@ -418,14 +418,14 @@ onMounted(async () => {
                   </span>
                   <span
                     v-if="user.roles.length === 0"
-                    class="text-xs sm:text-sm text-gray-500 dark:text-stone-400"
+                    class="text-xs sm:text-sm text-gray-500 dark:text-slate-400"
                   >
                     {{ t("userManagement.noRoles") }}
                   </span>
                 </div>
               </td>
               <td
-                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500 dark:text-stone-400"
+                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500 dark:text-slate-400"
               >
                 {{ formatDate(user.last_login) }}
               </td>
@@ -447,13 +447,13 @@ onMounted(async () => {
       <!-- Pagination - Desktop -->
       <div
         v-if="totalPages > 1"
-        class="bg-white dark:bg-stone-900 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-stone-700 sm:px-6"
+        class="bg-white dark:bg-slate-800 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-slate-700 sm:px-6"
       >
         <div
           class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between"
         >
           <div>
-            <p class="text-xs sm:text-sm text-gray-700 dark:text-stone-300">
+            <p class="text-xs sm:text-sm text-gray-700 dark:text-slate-300">
               {{ t("userManagement.showing") }}
               <span class="font-medium">{{ currentPage * perPage + 1 }}</span>
               {{ t("userManagement.to") }}
@@ -473,7 +473,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage - 1)"
                 :disabled="currentPage === 0"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-stone-700 bg-white dark:bg-stone-900 text-sm font-medium text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Previous</span>
                 <ChevronLeft class="h-5 w-5" />
@@ -486,7 +486,7 @@ onMounted(async () => {
                   'relative inline-flex items-center px-4 py-2 border text-sm font-medium cursor-pointer',
                   page - 1 === currentPage
                     ? 'z-10 bg-violet-50 dark:bg-violet-950/40 border-violet-500 text-violet-700 dark:text-violet-200'
-                    : 'bg-white dark:bg-stone-900 border-gray-300 dark:border-stone-700 text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800',
+                    : 'bg-white dark:bg-slate-800 border-gray-300 dark:border-slate-700 text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700',
                 ]"
               >
                 {{ page }}
@@ -494,7 +494,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage + 1)"
                 :disabled="currentPage >= totalPages - 1"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-stone-700 bg-white dark:bg-stone-900 text-sm font-medium text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Next</span>
                 <ChevronRight class="h-5 w-5" />
@@ -509,13 +509,13 @@ onMounted(async () => {
     <div class="sm:hidden space-y-3">
       <div
         v-if="loading"
-        class="text-center py-8 text-sm text-gray-500 dark:text-stone-400"
+        class="text-center py-8 text-sm text-gray-500 dark:text-slate-400"
       >
         {{ t("userManagement.loadingUsers") }}
       </div>
       <div
         v-else-if="filteredUsers.length === 0"
-        class="text-center py-8 text-sm text-gray-500 dark:text-stone-400"
+        class="text-center py-8 text-sm text-gray-500 dark:text-slate-400"
       >
         {{ t("userManagement.noUsersFound") }}
       </div>
@@ -523,7 +523,7 @@ onMounted(async () => {
         v-else
         v-for="user in filteredUsers"
         :key="user.id"
-        class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 p-3"
+        class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-3"
       >
         <div class="flex items-start justify-between mb-2">
           <div class="flex items-center flex-1 min-w-0">
@@ -545,11 +545,11 @@ onMounted(async () => {
             </div>
             <div class="min-w-0 flex-1">
               <div
-                class="text-xs font-medium text-gray-900 dark:text-stone-100 truncate"
+                class="text-xs font-medium text-gray-900 dark:text-slate-100 truncate"
               >
                 {{ user.name || user.nickname || "Unknown" }}
               </div>
-              <div class="text-xs text-gray-500 dark:text-stone-400 truncate">
+              <div class="text-xs text-gray-500 dark:text-slate-400 truncate">
                 {{ user.email }}
               </div>
             </div>
@@ -587,12 +587,12 @@ onMounted(async () => {
           </span>
           <span
             v-if="user.roles.length === 0"
-            class="text-xs text-gray-500 dark:text-stone-400"
+            class="text-xs text-gray-500 dark:text-slate-400"
           >
             {{ t("userManagement.noRoles") }}
           </span>
         </div>
-        <div class="mt-2 text-xs text-gray-500 dark:text-stone-400">
+        <div class="mt-2 text-xs text-gray-500 dark:text-slate-400">
           {{ t("userManagement.lastLogin") }}: {{ formatDate(user.last_login) }}
         </div>
       </div>
@@ -602,14 +602,14 @@ onMounted(async () => {
         <button
           @click="handlePageChange(currentPage - 1)"
           :disabled="currentPage === 0"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-stone-700 text-xs font-medium rounded-md text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-slate-700 text-xs font-medium rounded-md text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.previous") }}
         </button>
         <button
           @click="handlePageChange(currentPage + 1)"
           :disabled="currentPage >= totalPages - 1"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-stone-700 text-xs font-medium rounded-md text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-slate-700 text-xs font-medium rounded-md text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.next") }}
         </button>

--- a/components/UserManagement.vue
+++ b/components/UserManagement.vue
@@ -183,17 +183,19 @@ onMounted(async () => {
     <div class="mb-6 sm:mb-8 hidden sm:block">
       <div class="flex justify-between items-start">
         <div>
-          <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+          <h1
+            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-stone-100 mb-2"
+          >
             {{ t("userManagement.title") }}
           </h1>
-          <p class="text-sm sm:text-base text-gray-600">
+          <p class="text-sm sm:text-base text-gray-600 dark:text-stone-400">
             {{ t("userManagement.subtitle") }}
           </p>
         </div>
         <div class="ml-4 flex items-center gap-3">
           <button
             @click="navigateTo('/')"
-            class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors cursor-pointer"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 border border-gray-300 dark:border-stone-700 rounded-lg hover:bg-gray-50 dark:hover:bg-stone-800 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-stone-950 transition-colors cursor-pointer"
           >
             {{ t("userManagement.returnToHomepage") }}
           </button>
@@ -205,24 +207,24 @@ onMounted(async () => {
     <div class="mb-4 sm:hidden">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <h1 class="text-xl font-bold text-gray-900">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-stone-100">
             {{ t("userManagement.title") }}
           </h1>
         </div>
         <button
           type="button"
           @click="navigateTo('/')"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-stone-800 transition-colors"
           :aria-label="t('userManagement.returnToHomepage')"
         >
-          <Home class="w-6 h-6 text-gray-700" />
+          <Home class="w-6 h-6 text-gray-700 dark:text-stone-200" />
         </button>
       </div>
     </div>
 
     <!-- Search and Controls -->
     <div
-      class="bg-white rounded-lg shadow-sm border border-gray-200 p-3 sm:p-6 mb-4 sm:mb-6"
+      class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 p-3 sm:p-6 mb-4 sm:mb-6"
     >
       <div class="flex flex-col sm:flex-row gap-4 items-center justify-between">
         <div class="flex-1 max-w-md">
@@ -231,13 +233,15 @@ onMounted(async () => {
               v-model="searchQuery"
               type="text"
               :placeholder="t('userManagement.searchPlaceholder')"
-              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base bg-white dark:bg-stone-800 text-gray-900 dark:text-stone-100 placeholder-gray-400 dark:placeholder-stone-500 border border-gray-300 dark:border-stone-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
               @keyup.enter="handleSearch"
             />
             <div
               class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
             >
-              <Search class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400" />
+              <Search
+                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-stone-500"
+              />
             </div>
           </div>
         </div>
@@ -256,72 +260,80 @@ onMounted(async () => {
     <!-- Messages -->
     <div
       v-if="error"
-      class="mb-3 sm:mb-4 p-3 sm:p-4 bg-red-50 border border-red-200 rounded-lg"
+      class="mb-3 sm:mb-4 p-3 sm:p-4 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg"
     >
       <div class="flex">
         <XCircle
-          class="h-4 w-4 sm:h-5 sm:w-5 text-red-400 flex-shrink-0 mt-0.5"
+          class="h-4 w-4 sm:h-5 sm:w-5 text-red-400 dark:text-red-300 flex-shrink-0 mt-0.5"
         />
         <div class="ml-2 sm:ml-3">
-          <p class="text-xs sm:text-sm text-red-800">{{ error }}</p>
+          <p class="text-xs sm:text-sm text-red-800 dark:text-red-200">
+            {{ error }}
+          </p>
         </div>
       </div>
     </div>
 
     <div
       v-if="success"
-      class="mb-3 sm:mb-4 p-3 sm:p-4 bg-green-50 border border-green-200 rounded-lg"
+      class="mb-3 sm:mb-4 p-3 sm:p-4 bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-900 rounded-lg"
     >
       <div class="flex">
         <CheckCircle2
-          class="h-4 w-4 sm:h-5 sm:w-5 text-green-400 flex-shrink-0 mt-0.5"
+          class="h-4 w-4 sm:h-5 sm:w-5 text-green-400 dark:text-green-300 flex-shrink-0 mt-0.5"
         />
         <div class="ml-2 sm:ml-3">
-          <p class="text-xs sm:text-sm text-green-800">{{ success }}</p>
+          <p class="text-xs sm:text-sm text-green-800 dark:text-green-200">
+            {{ success }}
+          </p>
         </div>
       </div>
     </div>
 
     <!-- Users Table - Desktop -->
     <div
-      class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden hidden sm:block"
+      class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 overflow-hidden hidden sm:block"
     >
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
+        <table
+          class="min-w-full divide-y divide-gray-200 dark:divide-stone-700"
+        >
+          <thead class="bg-gray-50 dark:bg-stone-800">
             <tr>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.user") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.status") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.roles") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.lastLogin") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-stone-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.actions") }}
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody
+            class="bg-white dark:bg-stone-900 divide-y divide-gray-200 dark:divide-stone-700"
+          >
             <tr v-if="loading" class="animate-pulse">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-stone-400 text-sm"
               >
                 {{ t("userManagement.loadingUsers") }}
               </td>
@@ -329,7 +341,7 @@ onMounted(async () => {
             <tr v-else-if="filteredUsers.length === 0">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-stone-400 text-sm"
               >
                 {{ t("userManagement.noUsersFound") }}
               </td>
@@ -338,7 +350,7 @@ onMounted(async () => {
               v-else
               v-for="user in filteredUsers"
               :key="user.id"
-              class="hover:bg-gray-50"
+              class="hover:bg-gray-50 dark:hover:bg-stone-800"
             >
               <td class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap">
                 <div class="flex items-center">
@@ -366,10 +378,14 @@ onMounted(async () => {
                     </template>
                   </div>
                   <div class="ml-2 sm:ml-4">
-                    <div class="text-xs sm:text-sm font-medium text-gray-900">
+                    <div
+                      class="text-xs sm:text-sm font-medium text-gray-900 dark:text-stone-100"
+                    >
                       {{ user.name || user.nickname || "Unknown" }}
                     </div>
-                    <div class="text-xs sm:text-sm text-gray-500">
+                    <div
+                      class="text-xs sm:text-sm text-gray-500 dark:text-stone-400"
+                    >
                       {{ user.email }}
                     </div>
                   </div>
@@ -380,8 +396,8 @@ onMounted(async () => {
                   :class="[
                     'inline-flex px-2 py-1 text-xs font-semibold rounded-full',
                     user.isApproved
-                      ? 'bg-green-100 text-green-800'
-                      : 'bg-yellow-100 text-yellow-800',
+                      ? 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200'
+                      : 'bg-yellow-100 dark:bg-yellow-950/50 text-yellow-800 dark:text-yellow-200',
                   ]"
                 >
                   {{
@@ -396,20 +412,20 @@ onMounted(async () => {
                   <span
                     v-for="role in user.roles"
                     :key="role.id"
-                    class="inline-flex px-1.5 sm:px-2 py-0.5 sm:py-1 text-xs font-medium bg-violet-100 text-violet-800 rounded-full"
+                    class="inline-flex px-1.5 sm:px-2 py-0.5 sm:py-1 text-xs font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-800 dark:text-violet-200 rounded-full"
                   >
                     {{ translateRoleName(role.name, t) }}
                   </span>
                   <span
                     v-if="user.roles.length === 0"
-                    class="text-xs sm:text-sm text-gray-500"
+                    class="text-xs sm:text-sm text-gray-500 dark:text-stone-400"
                   >
                     {{ t("userManagement.noRoles") }}
                   </span>
                 </div>
               </td>
               <td
-                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500"
+                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500 dark:text-stone-400"
               >
                 {{ formatDate(user.last_login) }}
               </td>
@@ -431,13 +447,13 @@ onMounted(async () => {
       <!-- Pagination - Desktop -->
       <div
         v-if="totalPages > 1"
-        class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6"
+        class="bg-white dark:bg-stone-900 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-stone-700 sm:px-6"
       >
         <div
           class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between"
         >
           <div>
-            <p class="text-xs sm:text-sm text-gray-700">
+            <p class="text-xs sm:text-sm text-gray-700 dark:text-stone-300">
               {{ t("userManagement.showing") }}
               <span class="font-medium">{{ currentPage * perPage + 1 }}</span>
               {{ t("userManagement.to") }}
@@ -457,7 +473,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage - 1)"
                 :disabled="currentPage === 0"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-stone-700 bg-white dark:bg-stone-900 text-sm font-medium text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Previous</span>
                 <ChevronLeft class="h-5 w-5" />
@@ -469,8 +485,8 @@ onMounted(async () => {
                 :class="[
                   'relative inline-flex items-center px-4 py-2 border text-sm font-medium cursor-pointer',
                   page - 1 === currentPage
-                    ? 'z-10 bg-violet-50 border-violet-500 text-violet-700'
-                    : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50',
+                    ? 'z-10 bg-violet-50 dark:bg-violet-950/40 border-violet-500 text-violet-700 dark:text-violet-200'
+                    : 'bg-white dark:bg-stone-900 border-gray-300 dark:border-stone-700 text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800',
                 ]"
               >
                 {{ page }}
@@ -478,7 +494,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage + 1)"
                 :disabled="currentPage >= totalPages - 1"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-stone-700 bg-white dark:bg-stone-900 text-sm font-medium text-gray-500 dark:text-stone-400 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Next</span>
                 <ChevronRight class="h-5 w-5" />
@@ -491,12 +507,15 @@ onMounted(async () => {
 
     <!-- Users Cards - Mobile -->
     <div class="sm:hidden space-y-3">
-      <div v-if="loading" class="text-center py-8 text-sm text-gray-500">
+      <div
+        v-if="loading"
+        class="text-center py-8 text-sm text-gray-500 dark:text-stone-400"
+      >
         {{ t("userManagement.loadingUsers") }}
       </div>
       <div
         v-else-if="filteredUsers.length === 0"
-        class="text-center py-8 text-sm text-gray-500"
+        class="text-center py-8 text-sm text-gray-500 dark:text-stone-400"
       >
         {{ t("userManagement.noUsersFound") }}
       </div>
@@ -504,7 +523,7 @@ onMounted(async () => {
         v-else
         v-for="user in filteredUsers"
         :key="user.id"
-        class="bg-white rounded-lg shadow-sm border border-gray-200 p-3"
+        class="bg-white dark:bg-stone-900 rounded-lg shadow-sm border border-gray-200 dark:border-stone-700 p-3"
       >
         <div class="flex items-start justify-between mb-2">
           <div class="flex items-center flex-1 min-w-0">
@@ -525,10 +544,14 @@ onMounted(async () => {
               />
             </div>
             <div class="min-w-0 flex-1">
-              <div class="text-xs font-medium text-gray-900 truncate">
+              <div
+                class="text-xs font-medium text-gray-900 dark:text-stone-100 truncate"
+              >
                 {{ user.name || user.nickname || "Unknown" }}
               </div>
-              <div class="text-xs text-gray-500 truncate">{{ user.email }}</div>
+              <div class="text-xs text-gray-500 dark:text-stone-400 truncate">
+                {{ user.email }}
+              </div>
             </div>
           </div>
           <div class="ml-2">
@@ -545,8 +568,8 @@ onMounted(async () => {
             :class="[
               'inline-flex px-2 py-0.5 text-xs font-semibold rounded-full',
               user.isApproved
-                ? 'bg-green-100 text-green-800'
-                : 'bg-yellow-100 text-yellow-800',
+                ? 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200'
+                : 'bg-yellow-100 dark:bg-yellow-950/50 text-yellow-800 dark:text-yellow-200',
             ]"
           >
             {{
@@ -558,15 +581,18 @@ onMounted(async () => {
           <span
             v-for="role in user.roles"
             :key="role.id"
-            class="inline-flex px-2 py-0.5 text-xs font-medium bg-violet-100 text-violet-800 rounded-full"
+            class="inline-flex px-2 py-0.5 text-xs font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-800 dark:text-violet-200 rounded-full"
           >
             {{ translateRoleName(role.name, t) }}
           </span>
-          <span v-if="user.roles.length === 0" class="text-xs text-gray-500">
+          <span
+            v-if="user.roles.length === 0"
+            class="text-xs text-gray-500 dark:text-stone-400"
+          >
             {{ t("userManagement.noRoles") }}
           </span>
         </div>
-        <div class="mt-2 text-xs text-gray-500">
+        <div class="mt-2 text-xs text-gray-500 dark:text-stone-400">
           {{ t("userManagement.lastLogin") }}: {{ formatDate(user.last_login) }}
         </div>
       </div>
@@ -576,14 +602,14 @@ onMounted(async () => {
         <button
           @click="handlePageChange(currentPage - 1)"
           :disabled="currentPage === 0"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-stone-700 text-xs font-medium rounded-md text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.previous") }}
         </button>
         <button
           @click="handlePageChange(currentPage + 1)"
           :disabled="currentPage >= totalPages - 1"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-stone-700 text-xs font-medium rounded-md text-gray-700 dark:text-stone-200 bg-white dark:bg-stone-900 hover:bg-gray-50 dark:hover:bg-stone-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.next") }}
         </button>

--- a/components/UserManagement.vue
+++ b/components/UserManagement.vue
@@ -184,18 +184,18 @@ onMounted(async () => {
       <div class="flex justify-between items-start">
         <div>
           <h1
-            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2"
+            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-dusk-100 mb-2"
           >
             {{ t("userManagement.title") }}
           </h1>
-          <p class="text-sm sm:text-base text-gray-600 dark:text-slate-400">
+          <p class="text-sm sm:text-base text-gray-600 dark:text-dusk-400">
             {{ t("userManagement.subtitle") }}
           </p>
         </div>
         <div class="ml-4 flex items-center gap-3">
           <button
             @click="navigateTo('/')"
-            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 transition-colors cursor-pointer"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-dusk-200 bg-white dark:bg-dusk-800 border border-gray-300 dark:border-dusk-700 rounded-lg hover:bg-gray-50 dark:hover:bg-dusk-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-dusk-900 transition-colors cursor-pointer"
           >
             {{ t("userManagement.returnToHomepage") }}
           </button>
@@ -207,24 +207,24 @@ onMounted(async () => {
     <div class="mb-4 sm:hidden">
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <h1 class="text-xl font-bold text-gray-900 dark:text-slate-100">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-dusk-100">
             {{ t("userManagement.title") }}
           </h1>
         </div>
         <button
           type="button"
           @click="navigateTo('/')"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-dusk-700 transition-colors"
           :aria-label="t('userManagement.returnToHomepage')"
         >
-          <Home class="w-6 h-6 text-gray-700 dark:text-slate-200" />
+          <Home class="w-6 h-6 text-gray-700 dark:text-dusk-200" />
         </button>
       </div>
     </div>
 
     <!-- Search and Controls -->
     <div
-      class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-3 sm:p-6 mb-4 sm:mb-6"
+      class="bg-white dark:bg-dusk-800 rounded-lg shadow-sm border border-gray-200 dark:border-dusk-700 p-3 sm:p-6 mb-4 sm:mb-6"
     >
       <div class="flex flex-col sm:flex-row gap-4 items-center justify-between">
         <div class="flex-1 max-w-md">
@@ -233,14 +233,14 @@ onMounted(async () => {
               v-model="searchQuery"
               type="text"
               :placeholder="t('userManagement.searchPlaceholder')"
-              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500 border border-gray-300 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+              class="w-full pl-8 sm:pl-10 pr-3 sm:pr-4 py-1.5 sm:py-2 text-sm sm:text-base bg-white dark:bg-dusk-700 text-gray-900 dark:text-dusk-100 placeholder-gray-400 dark:placeholder-dusk-500 border border-gray-300 dark:border-dusk-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
               @keyup.enter="handleSearch"
             />
             <div
               class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
             >
               <Search
-                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-slate-500"
+                class="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-dusk-500"
               />
             </div>
           </div>
@@ -292,48 +292,46 @@ onMounted(async () => {
 
     <!-- Users Table - Desktop -->
     <div
-      class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 overflow-hidden hidden sm:block"
+      class="bg-white dark:bg-dusk-800 rounded-lg shadow-sm border border-gray-200 dark:border-dusk-700 overflow-hidden hidden sm:block"
     >
       <div class="overflow-x-auto">
-        <table
-          class="min-w-full divide-y divide-gray-200 dark:divide-slate-700"
-        >
-          <thead class="bg-gray-50 dark:bg-slate-700">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-dusk-700">
+          <thead class="bg-gray-50 dark:bg-dusk-700">
             <tr>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.user") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.status") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.roles") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.lastLogin") }}
               </th>
               <th
-                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider"
+                class="px-4 sm:px-6 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wider"
               >
                 {{ t("userManagement.actions") }}
               </th>
             </tr>
           </thead>
           <tbody
-            class="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700"
+            class="bg-white dark:bg-dusk-800 divide-y divide-gray-200 dark:divide-dusk-700"
           >
             <tr v-if="loading" class="animate-pulse">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-slate-400 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-dusk-400 text-sm"
               >
                 {{ t("userManagement.loadingUsers") }}
               </td>
@@ -341,7 +339,7 @@ onMounted(async () => {
             <tr v-else-if="filteredUsers.length === 0">
               <td
                 colspan="5"
-                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-slate-400 text-sm"
+                class="px-4 sm:px-6 py-8 sm:py-12 text-center text-gray-500 dark:text-dusk-400 text-sm"
               >
                 {{ t("userManagement.noUsersFound") }}
               </td>
@@ -350,7 +348,7 @@ onMounted(async () => {
               v-else
               v-for="user in filteredUsers"
               :key="user.id"
-              class="hover:bg-gray-50 dark:hover:bg-slate-700"
+              class="hover:bg-gray-50 dark:hover:bg-dusk-700"
             >
               <td class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap">
                 <div class="flex items-center">
@@ -379,12 +377,12 @@ onMounted(async () => {
                   </div>
                   <div class="ml-2 sm:ml-4">
                     <div
-                      class="text-xs sm:text-sm font-medium text-gray-900 dark:text-slate-100"
+                      class="text-xs sm:text-sm font-medium text-gray-900 dark:text-dusk-100"
                     >
                       {{ user.name || user.nickname || "Unknown" }}
                     </div>
                     <div
-                      class="text-xs sm:text-sm text-gray-500 dark:text-slate-400"
+                      class="text-xs sm:text-sm text-gray-500 dark:text-dusk-400"
                     >
                       {{ user.email }}
                     </div>
@@ -418,14 +416,14 @@ onMounted(async () => {
                   </span>
                   <span
                     v-if="user.roles.length === 0"
-                    class="text-xs sm:text-sm text-gray-500 dark:text-slate-400"
+                    class="text-xs sm:text-sm text-gray-500 dark:text-dusk-400"
                   >
                     {{ t("userManagement.noRoles") }}
                   </span>
                 </div>
               </td>
               <td
-                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500 dark:text-slate-400"
+                class="px-4 sm:px-6 py-3 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-gray-500 dark:text-dusk-400"
               >
                 {{ formatDate(user.last_login) }}
               </td>
@@ -447,13 +445,13 @@ onMounted(async () => {
       <!-- Pagination - Desktop -->
       <div
         v-if="totalPages > 1"
-        class="bg-white dark:bg-slate-800 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-slate-700 sm:px-6"
+        class="bg-white dark:bg-dusk-800 px-4 py-3 flex items-center justify-between border-t border-gray-200 dark:border-dusk-700 sm:px-6"
       >
         <div
           class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between"
         >
           <div>
-            <p class="text-xs sm:text-sm text-gray-700 dark:text-slate-300">
+            <p class="text-xs sm:text-sm text-gray-700 dark:text-dusk-300">
               {{ t("userManagement.showing") }}
               <span class="font-medium">{{ currentPage * perPage + 1 }}</span>
               {{ t("userManagement.to") }}
@@ -473,7 +471,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage - 1)"
                 :disabled="currentPage === 0"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-dusk-700 bg-white dark:bg-dusk-800 text-sm font-medium text-gray-500 dark:text-dusk-400 hover:bg-gray-50 dark:hover:bg-dusk-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Previous</span>
                 <ChevronLeft class="h-5 w-5" />
@@ -486,7 +484,7 @@ onMounted(async () => {
                   'relative inline-flex items-center px-4 py-2 border text-sm font-medium cursor-pointer',
                   page - 1 === currentPage
                     ? 'z-10 bg-violet-50 dark:bg-violet-950/40 border-violet-500 text-violet-700 dark:text-violet-200'
-                    : 'bg-white dark:bg-slate-800 border-gray-300 dark:border-slate-700 text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700',
+                    : 'bg-white dark:bg-dusk-800 border-gray-300 dark:border-dusk-700 text-gray-500 dark:text-dusk-400 hover:bg-gray-50 dark:hover:bg-dusk-700',
                 ]"
               >
                 {{ page }}
@@ -494,7 +492,7 @@ onMounted(async () => {
               <button
                 @click="handlePageChange(currentPage + 1)"
                 :disabled="currentPage >= totalPages - 1"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-gray-500 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-dusk-700 bg-white dark:bg-dusk-800 text-sm font-medium text-gray-500 dark:text-dusk-400 hover:bg-gray-50 dark:hover:bg-dusk-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span class="sr-only">Next</span>
                 <ChevronRight class="h-5 w-5" />
@@ -509,13 +507,13 @@ onMounted(async () => {
     <div class="sm:hidden space-y-3">
       <div
         v-if="loading"
-        class="text-center py-8 text-sm text-gray-500 dark:text-slate-400"
+        class="text-center py-8 text-sm text-gray-500 dark:text-dusk-400"
       >
         {{ t("userManagement.loadingUsers") }}
       </div>
       <div
         v-else-if="filteredUsers.length === 0"
-        class="text-center py-8 text-sm text-gray-500 dark:text-slate-400"
+        class="text-center py-8 text-sm text-gray-500 dark:text-dusk-400"
       >
         {{ t("userManagement.noUsersFound") }}
       </div>
@@ -523,7 +521,7 @@ onMounted(async () => {
         v-else
         v-for="user in filteredUsers"
         :key="user.id"
-        class="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-3"
+        class="bg-white dark:bg-dusk-800 rounded-lg shadow-sm border border-gray-200 dark:border-dusk-700 p-3"
       >
         <div class="flex items-start justify-between mb-2">
           <div class="flex items-center flex-1 min-w-0">
@@ -545,11 +543,11 @@ onMounted(async () => {
             </div>
             <div class="min-w-0 flex-1">
               <div
-                class="text-xs font-medium text-gray-900 dark:text-slate-100 truncate"
+                class="text-xs font-medium text-gray-900 dark:text-dusk-100 truncate"
               >
                 {{ user.name || user.nickname || "Unknown" }}
               </div>
-              <div class="text-xs text-gray-500 dark:text-slate-400 truncate">
+              <div class="text-xs text-gray-500 dark:text-dusk-400 truncate">
                 {{ user.email }}
               </div>
             </div>
@@ -587,12 +585,12 @@ onMounted(async () => {
           </span>
           <span
             v-if="user.roles.length === 0"
-            class="text-xs text-gray-500 dark:text-slate-400"
+            class="text-xs text-gray-500 dark:text-dusk-400"
           >
             {{ t("userManagement.noRoles") }}
           </span>
         </div>
-        <div class="mt-2 text-xs text-gray-500 dark:text-slate-400">
+        <div class="mt-2 text-xs text-gray-500 dark:text-dusk-400">
           {{ t("userManagement.lastLogin") }}: {{ formatDate(user.last_login) }}
         </div>
       </div>
@@ -602,14 +600,14 @@ onMounted(async () => {
         <button
           @click="handlePageChange(currentPage - 1)"
           :disabled="currentPage === 0"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-slate-700 text-xs font-medium rounded-md text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-dusk-700 text-xs font-medium rounded-md text-gray-700 dark:text-dusk-200 bg-white dark:bg-dusk-800 hover:bg-gray-50 dark:hover:bg-dusk-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.previous") }}
         </button>
         <button
           @click="handlePageChange(currentPage + 1)"
           :disabled="currentPage >= totalPages - 1"
-          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-slate-700 text-xs font-medium rounded-md text-gray-700 dark:text-slate-200 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-dusk-700 text-xs font-medium rounded-md text-gray-700 dark:text-dusk-200 bg-white dark:bg-dusk-800 hover:bg-gray-50 dark:hover:bg-dusk-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ t("userManagement.next") }}
         </button>

--- a/components/homepage/DataSourcesGrid.vue
+++ b/components/homepage/DataSourcesGrid.vue
@@ -53,10 +53,10 @@ const otherIntegrations = [
 <template>
   <section>
     <div class="mb-8 text-center">
-      <h2 class="mb-3 text-3xl font-bold text-gray-900 dark:text-slate-100">
+      <h2 class="mb-3 text-3xl font-bold text-gray-900 dark:text-dusk-100">
         {{ t("dataSources.heading") }}
       </h2>
-      <p class="mx-auto max-w-2xl text-base text-gray-600 dark:text-slate-400">
+      <p class="mx-auto max-w-2xl text-base text-gray-600 dark:text-dusk-400">
         {{ t("dataSources.subheading") }}
       </p>
     </div>
@@ -79,13 +79,13 @@ const otherIntegrations = [
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-dusk-100"
         >
           {{ source.name }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-dusk-400"
         >
           {{ t(`dataSources.${source.descriptionKey}`) }}
         </p>
@@ -94,7 +94,7 @@ const otherIntegrations = [
           <span
             v-for="tag in source.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
+            class="rounded-full border border-gray-200 dark:border-dusk-700 bg-white dark:bg-dusk-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-dusk-300"
           >
             {{ t(`dataSources.tags.${tag}`) }}
           </span>
@@ -114,13 +114,13 @@ const otherIntegrations = [
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-dusk-100"
         >
           {{ t("dataSources.otherHeading") }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-dusk-400"
         >
           {{ t("dataSources.otherDescription") }}
         </p>
@@ -129,7 +129,7 @@ const otherIntegrations = [
           <span
             v-for="example in otherIntegrations"
             :key="example"
-            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
+            class="rounded-full border border-gray-200 dark:border-dusk-700 bg-white dark:bg-dusk-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-dusk-300"
           >
             {{ example }}
           </span>

--- a/components/homepage/DataSourcesGrid.vue
+++ b/components/homepage/DataSourcesGrid.vue
@@ -53,10 +53,10 @@ const otherIntegrations = [
 <template>
   <section>
     <div class="mb-8 text-center">
-      <h2 class="mb-3 text-3xl font-bold text-gray-900 dark:text-stone-100">
+      <h2 class="mb-3 text-3xl font-bold text-gray-900 dark:text-slate-100">
         {{ t("dataSources.heading") }}
       </h2>
-      <p class="mx-auto max-w-2xl text-base text-gray-600 dark:text-stone-400">
+      <p class="mx-auto max-w-2xl text-base text-gray-600 dark:text-slate-400">
         {{ t("dataSources.subheading") }}
       </p>
     </div>
@@ -79,13 +79,13 @@ const otherIntegrations = [
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
         >
           {{ source.name }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
         >
           {{ t(`dataSources.${source.descriptionKey}`) }}
         </p>
@@ -94,7 +94,7 @@ const otherIntegrations = [
           <span
             v-for="tag in source.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
+            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
           >
             {{ t(`dataSources.tags.${tag}`) }}
           </span>
@@ -114,13 +114,13 @@ const otherIntegrations = [
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
         >
           {{ t("dataSources.otherHeading") }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
         >
           {{ t("dataSources.otherDescription") }}
         </p>
@@ -129,7 +129,7 @@ const otherIntegrations = [
           <span
             v-for="example in otherIntegrations"
             :key="example"
-            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
+            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
           >
             {{ example }}
           </span>

--- a/components/homepage/DataSourcesGrid.vue
+++ b/components/homepage/DataSourcesGrid.vue
@@ -53,10 +53,10 @@ const otherIntegrations = [
 <template>
   <section>
     <div class="mb-8 text-center">
-      <h2 class="mb-3 text-3xl font-bold text-gray-900">
+      <h2 class="mb-3 text-3xl font-bold text-gray-900 dark:text-stone-100">
         {{ t("dataSources.heading") }}
       </h2>
-      <p class="mx-auto max-w-2xl text-base text-gray-600">
+      <p class="mx-auto max-w-2xl text-base text-gray-600 dark:text-stone-400">
         {{ t("dataSources.subheading") }}
       </p>
     </div>
@@ -68,7 +68,7 @@ const otherIntegrations = [
         :href="source.url"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-emerald-100 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
+        class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-emerald-200 dark:border-emerald-800 bg-gradient-to-br from-emerald-50 to-emerald-100 dark:from-emerald-950/40 dark:to-emerald-900/40 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
       >
         <div class="mb-4 flex h-[80px] items-center justify-center">
           <img
@@ -78,11 +78,15 @@ const otherIntegrations = [
           />
         </div>
 
-        <h3 class="mb-3 text-center text-xl font-bold text-gray-900">
+        <h3
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+        >
           {{ source.name }}
         </h3>
 
-        <p class="mb-4 min-h-[3rem] text-center text-sm text-gray-600">
+        <p
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+        >
           {{ t(`dataSources.${source.descriptionKey}`) }}
         </p>
 
@@ -90,7 +94,7 @@ const otherIntegrations = [
           <span
             v-for="tag in source.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700"
+            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
           >
             {{ t(`dataSources.tags.${tag}`) }}
           </span>
@@ -98,22 +102,26 @@ const otherIntegrations = [
       </a>
 
       <div
-        class="flex w-full max-w-sm cursor-default flex-col rounded-2xl border-2 border-dashed border-emerald-300 bg-gradient-to-br from-emerald-50 to-emerald-100 p-6 md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
+        class="flex w-full max-w-sm cursor-default flex-col rounded-2xl border-2 border-dashed border-emerald-300 dark:border-emerald-800 bg-gradient-to-br from-emerald-50 to-emerald-100 dark:from-emerald-950/40 dark:to-emerald-900/40 p-6 md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
       >
         <div class="mb-4 flex h-[80px] items-center justify-center">
           <span
-            class="select-none font-mono text-6xl font-bold leading-none text-emerald-700"
+            class="select-none font-mono text-6xl font-bold leading-none text-emerald-700 dark:text-emerald-200"
             aria-hidden="true"
           >
             {&nbsp;}
           </span>
         </div>
 
-        <h3 class="mb-3 text-center text-xl font-bold text-gray-900">
+        <h3
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+        >
           {{ t("dataSources.otherHeading") }}
         </h3>
 
-        <p class="mb-4 min-h-[3rem] text-center text-sm text-gray-600">
+        <p
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+        >
           {{ t("dataSources.otherDescription") }}
         </p>
 
@@ -121,12 +129,12 @@ const otherIntegrations = [
           <span
             v-for="example in otherIntegrations"
             :key="example"
-            class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700"
+            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
           >
             {{ example }}
           </span>
           <span
-            class="rounded-full bg-emerald-200 px-3 py-1 text-xs font-medium italic text-emerald-900"
+            class="rounded-full bg-emerald-200 dark:bg-emerald-900 px-3 py-1 text-xs font-medium italic text-emerald-900 dark:text-emerald-200"
           >
             {{ t("dataSources.andMore") }}
           </span>

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -162,13 +162,13 @@ const translateTag = (tag: string) => {
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
         >
           {{ service.name }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
         >
           {{ getServiceDescription(service.name) }}
         </p>
@@ -177,7 +177,7 @@ const translateTag = (tag: string) => {
           <span
             v-for="tag in service.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
+            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
           >
             {{ translateTag(tag) }}
           </span>
@@ -187,19 +187,19 @@ const translateTag = (tag: string) => {
 
     <div v-else class="py-16 text-center">
       <div
-        class="mx-auto max-w-md rounded-2xl border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-8 shadow-sm"
+        class="mx-auto max-w-md rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-8 shadow-sm"
       >
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 dark:bg-stone-700"
+          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 dark:bg-slate-600"
         >
-          <Smile class="h-8 w-8 text-gray-500 dark:text-stone-400" />
+          <Smile class="h-8 w-8 text-gray-500 dark:text-slate-400" />
         </div>
         <h3
-          class="mb-2 text-xl font-semibold text-gray-900 dark:text-stone-100"
+          class="mb-2 text-xl font-semibold text-gray-900 dark:text-slate-100"
         >
           {{ t("services.noServicesAvailable") }}
         </h3>
-        <p class="mb-4 text-gray-600 dark:text-stone-400">
+        <p class="mb-4 text-gray-600 dark:text-slate-400">
           {{ t("services.noServicesDescription") }}
         </p>
       </div>

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -115,7 +115,7 @@ const translateTag = (tag: string) => {
       <div
         v-for="service in availableServices"
         :key="service.name"
-        class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-violet-200 bg-gradient-to-br from-violet-50 to-violet-100 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
+        class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-violet-200 dark:border-violet-900 bg-gradient-to-br from-violet-50 to-violet-100 dark:from-violet-950/40 dark:to-violet-900/40 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
         @click="openService(service.url)"
       >
         <div class="mb-4 flex justify-center">
@@ -161,11 +161,15 @@ const translateTag = (tag: string) => {
           </div>
         </div>
 
-        <h3 class="mb-3 text-center text-xl font-bold text-gray-900">
+        <h3
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-stone-100"
+        >
           {{ service.name }}
         </h3>
 
-        <p class="mb-4 min-h-[3rem] text-center text-sm text-gray-600">
+        <p
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-stone-400"
+        >
           {{ getServiceDescription(service.name) }}
         </p>
 
@@ -173,7 +177,7 @@ const translateTag = (tag: string) => {
           <span
             v-for="tag in service.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700"
+            class="rounded-full border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-3 py-1 text-xs font-medium text-gray-700 dark:text-stone-300"
           >
             {{ translateTag(tag) }}
           </span>
@@ -183,17 +187,19 @@ const translateTag = (tag: string) => {
 
     <div v-else class="py-16 text-center">
       <div
-        class="mx-auto max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm"
+        class="mx-auto max-w-md rounded-2xl border border-gray-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-8 shadow-sm"
       >
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300"
+          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 dark:bg-stone-700"
         >
-          <Smile class="h-8 w-8 text-gray-500" />
+          <Smile class="h-8 w-8 text-gray-500 dark:text-stone-400" />
         </div>
-        <h3 class="mb-2 text-xl font-semibold text-gray-900">
+        <h3
+          class="mb-2 text-xl font-semibold text-gray-900 dark:text-stone-100"
+        >
           {{ t("services.noServicesAvailable") }}
         </h3>
-        <p class="mb-4 text-gray-600">
+        <p class="mb-4 text-gray-600 dark:text-stone-400">
           {{ t("services.noServicesDescription") }}
         </p>
       </div>

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -162,13 +162,13 @@ const translateTag = (tag: string) => {
         </div>
 
         <h3
-          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-slate-100"
+          class="mb-3 text-center text-xl font-bold text-gray-900 dark:text-dusk-100"
         >
           {{ service.name }}
         </h3>
 
         <p
-          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-slate-400"
+          class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-dusk-400"
         >
           {{ getServiceDescription(service.name) }}
         </p>
@@ -177,7 +177,7 @@ const translateTag = (tag: string) => {
           <span
             v-for="tag in service.tags"
             :key="tag"
-            class="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-slate-300"
+            class="rounded-full border border-gray-200 dark:border-dusk-700 bg-white dark:bg-dusk-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-dusk-300"
           >
             {{ translateTag(tag) }}
           </span>
@@ -187,19 +187,17 @@ const translateTag = (tag: string) => {
 
     <div v-else class="py-16 text-center">
       <div
-        class="mx-auto max-w-md rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-8 shadow-sm"
+        class="mx-auto max-w-md rounded-2xl border border-gray-200 dark:border-dusk-700 bg-white dark:bg-dusk-800 p-8 shadow-sm"
       >
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 dark:bg-slate-600"
+          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 dark:bg-dusk-600"
         >
-          <Smile class="h-8 w-8 text-gray-500 dark:text-slate-400" />
+          <Smile class="h-8 w-8 text-gray-500 dark:text-dusk-400" />
         </div>
-        <h3
-          class="mb-2 text-xl font-semibold text-gray-900 dark:text-slate-100"
-        >
+        <h3 class="mb-2 text-xl font-semibold text-gray-900 dark:text-dusk-100">
           {{ t("services.noServicesAvailable") }}
         </h3>
-        <p class="mb-4 text-gray-600 dark:text-slate-400">
+        <p class="mb-4 text-gray-600 dark:text-dusk-400">
           {{ t("services.noServicesDescription") }}
         </p>
       </div>

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -4,6 +4,7 @@ import { computed, ref } from "vue";
 import { Role } from "~/types/types";
 import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
 import HeaderBrand from "@/components/shared/HeaderBrand.vue";
+import ThemeToggle from "@/components/shared/ThemeToggle.vue";
 import { translateRoleName } from "@/utils/roleTranslations";
 import { useAuthActions } from "@/composables/useAuth";
 import {
@@ -46,7 +47,7 @@ const { login, logout } = useAuthActions();
 
 <template>
   <header
-    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 w-5/6 place-self-center mt-2 rounded-xl p-3"
+    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 dark:from-violet-950 dark:to-stone-900 w-5/6 place-self-center mt-2 rounded-xl p-3"
   >
     <!-- Desktop Layout - show above 1000px -->
     <div class="flex max-[1000px]:hidden relative items-end justify-around">
@@ -114,11 +115,13 @@ const { login, logout } = useAuthActions();
           v-if="isAuth0Configured && loggedIn"
           class="flex items-center space-x-3"
         >
-          <div class="text-sm max-[1200px]:text-xs text-gray-700">
+          <div
+            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-stone-300"
+          >
             {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             <span
               v-if="(user as User)?.roles?.length"
-              class="text-xs max-[1200px]:text-[10px] text-gray-500"
+              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-stone-400"
             >
               ({{
                 (user as User)?.roles
@@ -129,7 +132,7 @@ const { login, logout } = useAuthActions();
           </div>
           <button
             @click="logout"
-            class="text-gray-600 hover:text-gray-900 transition-colors text-sm max-[1200px]:text-xs"
+            class="text-gray-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors text-sm max-[1200px]:text-xs"
           >
             {{ t("auth.signOut") }}
           </button>
@@ -142,15 +145,26 @@ const { login, logout } = useAuthActions();
         >
           <NuxtLink
             to="/admin/users"
-            class="w-10 h-10 rounded-full bg-white flex items-center justify-center hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500"
+            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-stone-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-900"
           >
-            <Users class="w-5 h-5 text-gray-600" />
+            <Users class="w-5 h-5 text-gray-600 dark:text-stone-300" />
           </NuxtLink>
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("auth.userManagement") }}
+          </div>
+        </div>
+
+        <!-- Theme Toggle -->
+        <div class="relative group">
+          <ThemeToggle theme="white" variant="icon" />
+          <!-- Tooltip -->
+          <div
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+          >
+            {{ t("header.themeToggle") }}
           </div>
         </div>
 
@@ -159,7 +173,7 @@ const { login, logout } = useAuthActions();
           <GlobeLanguagePicker theme="white" variant="icon" />
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("header.languagePicker") }}
           </div>
@@ -177,11 +191,11 @@ const { login, logout } = useAuthActions();
         <!-- User Icon with Checkmark (if logged in) -->
         <div v-if="isAuth0Configured && loggedIn" class="relative">
           <div
-            class="w-10 h-10 rounded-full bg-white border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-stone-800 rounded-full"
             />
           </div>
         </div>
@@ -189,10 +203,10 @@ const { login, logout } = useAuthActions();
         <!-- Hamburger Menu Button -->
         <button
           @click="toggleMobileMenu"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 dark:hover:bg-stone-700 transition-colors"
           aria-label="Menu"
         >
-          <Menu class="w-6 h-6 text-gray-700" />
+          <Menu class="w-6 h-6 text-gray-700 dark:text-stone-200" />
         </button>
       </div>
     </div>
@@ -200,26 +214,26 @@ const { login, logout } = useAuthActions();
     <!-- Mobile Menu Dropdown -->
     <div
       v-if="mobileMenuOpen && isAuth0Configured && loggedIn"
-      class="hidden max-[1000px]:block mt-4 p-4 bg-white rounded-lg border border-violet-200 shadow-lg"
+      class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-stone-900 rounded-lg border border-violet-200 dark:border-stone-700 shadow-lg"
     >
       <!-- Welcome Message -->
-      <div class="mb-4 pb-4 border-b border-violet-200">
+      <div class="mb-4 pb-4 border-b border-violet-200 dark:border-stone-700">
         <div class="flex items-center space-x-3">
           <div
-            class="w-10 h-10 rounded-full bg-white border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-stone-800 rounded-full"
             />
           </div>
           <div>
-            <p class="text-sm font-semibold text-gray-900">
+            <p class="text-sm font-semibold text-gray-900 dark:text-stone-100">
               {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             </p>
             <p
               v-if="(user as User)?.roles?.length"
-              class="text-xs text-gray-500"
+              class="text-xs text-gray-500 dark:text-stone-400"
             >
               {{
                 (user as User)?.roles
@@ -236,13 +250,16 @@ const { login, logout } = useAuthActions();
         v-if="isAdmin"
         to="/admin/users"
         @click="mobileMenuOpen = false"
-        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 transition-colors mb-2"
+        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-stone-800 transition-colors mb-2"
       >
-        <Users class="w-5 h-5 text-gray-600" />
-        <span class="text-sm text-gray-700">{{
+        <Users class="w-5 h-5 text-gray-600 dark:text-stone-300" />
+        <span class="text-sm text-gray-700 dark:text-stone-200">{{
           t("auth.userManagement")
         }}</span>
       </NuxtLink>
+
+      <!-- Theme Toggle -->
+      <ThemeToggle variant="mobile" />
 
       <!-- Language Picker -->
       <GlobeLanguagePicker variant="mobile" />
@@ -253,10 +270,10 @@ const { login, logout } = useAuthActions();
           logout();
           mobileMenuOpen = false;
         "
-        class="w-full flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-red-50 transition-colors text-left"
+        class="w-full flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/40 transition-colors text-left"
       >
-        <LogOut class="w-5 h-5 text-red-600" />
-        <span class="text-sm text-red-600 font-medium">{{
+        <LogOut class="w-5 h-5 text-red-600 dark:text-red-300" />
+        <span class="text-sm text-red-600 dark:text-red-300 font-medium">{{
           t("auth.signOut")
         }}</span>
       </button>

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -47,7 +47,7 @@ const { login, logout } = useAuthActions();
 
 <template>
   <header
-    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 dark:from-violet-950 dark:to-slate-800 w-5/6 place-self-center mt-2 rounded-xl p-3"
+    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 dark:from-violet-950 dark:to-dusk-800 w-5/6 place-self-center mt-2 rounded-xl p-3"
   >
     <!-- Desktop Layout - show above 1000px -->
     <div class="flex max-[1000px]:hidden relative items-end justify-around">
@@ -116,12 +116,12 @@ const { login, logout } = useAuthActions();
           class="flex items-center space-x-3"
         >
           <div
-            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-slate-300"
+            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-dusk-300"
           >
             {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             <span
               v-if="(user as User)?.roles?.length"
-              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-slate-400"
+              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-dusk-400"
             >
               ({{
                 (user as User)?.roles
@@ -132,7 +132,7 @@ const { login, logout } = useAuthActions();
           </div>
           <button
             @click="logout"
-            class="text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors text-sm max-[1200px]:text-xs"
+            class="text-gray-600 hover:text-gray-900 dark:text-dusk-400 dark:hover:text-dusk-100 transition-colors text-sm max-[1200px]:text-xs"
           >
             {{ t("auth.signOut") }}
           </button>
@@ -145,13 +145,13 @@ const { login, logout } = useAuthActions();
         >
           <NuxtLink
             to="/admin/users"
-            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-800"
+            class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-dusk-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-800"
           >
-            <Users class="w-5 h-5 text-gray-600 dark:text-slate-300" />
+            <Users class="w-5 h-5 text-gray-600 dark:text-dusk-300" />
           </NuxtLink>
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-dusk-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("auth.userManagement") }}
           </div>
@@ -162,7 +162,7 @@ const { login, logout } = useAuthActions();
           <ThemeToggle theme="white" variant="icon" />
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-dusk-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("header.themeToggle") }}
           </div>
@@ -173,7 +173,7 @@ const { login, logout } = useAuthActions();
           <GlobeLanguagePicker theme="white" variant="icon" />
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-dusk-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("header.languagePicker") }}
           </div>
@@ -191,11 +191,11 @@ const { login, logout } = useAuthActions();
         <!-- User Icon with Checkmark (if logged in) -->
         <div v-if="isAuth0Configured && loggedIn" class="relative">
           <div
-            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-slate-700 rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-dusk-700 rounded-full"
             />
           </div>
         </div>
@@ -203,10 +203,10 @@ const { login, logout } = useAuthActions();
         <!-- Hamburger Menu Button -->
         <button
           @click="toggleMobileMenu"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 dark:hover:bg-slate-600 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 dark:hover:bg-dusk-600 transition-colors"
           aria-label="Menu"
         >
-          <Menu class="w-6 h-6 text-gray-700 dark:text-slate-200" />
+          <Menu class="w-6 h-6 text-gray-700 dark:text-dusk-200" />
         </button>
       </div>
     </div>
@@ -214,26 +214,26 @@ const { login, logout } = useAuthActions();
     <!-- Mobile Menu Dropdown -->
     <div
       v-if="mobileMenuOpen && isAuth0Configured && loggedIn"
-      class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-slate-800 rounded-lg border border-violet-200 dark:border-slate-700 shadow-lg"
+      class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-dusk-800 rounded-lg border border-violet-200 dark:border-dusk-700 shadow-lg"
     >
       <!-- Welcome Message -->
-      <div class="mb-4 pb-4 border-b border-violet-200 dark:border-slate-700">
+      <div class="mb-4 pb-4 border-b border-violet-200 dark:border-dusk-700">
         <div class="flex items-center space-x-3">
           <div
-            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-slate-700 rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-dusk-700 rounded-full"
             />
           </div>
           <div>
-            <p class="text-sm font-semibold text-gray-900 dark:text-slate-100">
+            <p class="text-sm font-semibold text-gray-900 dark:text-dusk-100">
               {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             </p>
             <p
               v-if="(user as User)?.roles?.length"
-              class="text-xs text-gray-500 dark:text-slate-400"
+              class="text-xs text-gray-500 dark:text-dusk-400"
             >
               {{
                 (user as User)?.roles
@@ -250,10 +250,10 @@ const { login, logout } = useAuthActions();
         v-if="isAdmin"
         to="/admin/users"
         @click="mobileMenuOpen = false"
-        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-slate-700 transition-colors mb-2"
+        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-dusk-700 transition-colors mb-2"
       >
-        <Users class="w-5 h-5 text-gray-600 dark:text-slate-300" />
-        <span class="text-sm text-gray-700 dark:text-slate-200">{{
+        <Users class="w-5 h-5 text-gray-600 dark:text-dusk-300" />
+        <span class="text-sm text-gray-700 dark:text-dusk-200">{{
           t("auth.userManagement")
         }}</span>
       </NuxtLink>

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -47,7 +47,7 @@ const { login, logout } = useAuthActions();
 
 <template>
   <header
-    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 dark:from-violet-950 dark:to-stone-900 w-5/6 place-self-center mt-2 rounded-xl p-3"
+    class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 dark:from-violet-950 dark:to-slate-800 w-5/6 place-self-center mt-2 rounded-xl p-3"
   >
     <!-- Desktop Layout - show above 1000px -->
     <div class="flex max-[1000px]:hidden relative items-end justify-around">
@@ -116,12 +116,12 @@ const { login, logout } = useAuthActions();
           class="flex items-center space-x-3"
         >
           <div
-            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-stone-300"
+            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-slate-300"
           >
             {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             <span
               v-if="(user as User)?.roles?.length"
-              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-stone-400"
+              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-slate-400"
             >
               ({{
                 (user as User)?.roles
@@ -132,7 +132,7 @@ const { login, logout } = useAuthActions();
           </div>
           <button
             @click="logout"
-            class="text-gray-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors text-sm max-[1200px]:text-xs"
+            class="text-gray-600 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors text-sm max-[1200px]:text-xs"
           >
             {{ t("auth.signOut") }}
           </button>
@@ -145,13 +145,13 @@ const { login, logout } = useAuthActions();
         >
           <NuxtLink
             to="/admin/users"
-            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-stone-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-900"
+            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-800"
           >
-            <Users class="w-5 h-5 text-gray-600 dark:text-stone-300" />
+            <Users class="w-5 h-5 text-gray-600 dark:text-slate-300" />
           </NuxtLink>
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("auth.userManagement") }}
           </div>
@@ -162,7 +162,7 @@ const { login, logout } = useAuthActions();
           <ThemeToggle theme="white" variant="icon" />
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("header.themeToggle") }}
           </div>
@@ -173,7 +173,7 @@ const { login, logout } = useAuthActions();
           <GlobeLanguagePicker theme="white" variant="icon" />
           <!-- Tooltip -->
           <div
-            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-stone-700 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-slate-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
           >
             {{ t("header.languagePicker") }}
           </div>
@@ -191,11 +191,11 @@ const { login, logout } = useAuthActions();
         <!-- User Icon with Checkmark (if logged in) -->
         <div v-if="isAuth0Configured && loggedIn" class="relative">
           <div
-            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-stone-800 rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-slate-700 rounded-full"
             />
           </div>
         </div>
@@ -203,10 +203,10 @@ const { login, logout } = useAuthActions();
         <!-- Hamburger Menu Button -->
         <button
           @click="toggleMobileMenu"
-          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 dark:hover:bg-stone-700 transition-colors"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-violet-200 dark:hover:bg-slate-600 transition-colors"
           aria-label="Menu"
         >
-          <Menu class="w-6 h-6 text-gray-700 dark:text-stone-200" />
+          <Menu class="w-6 h-6 text-gray-700 dark:text-slate-200" />
         </button>
       </div>
     </div>
@@ -214,26 +214,26 @@ const { login, logout } = useAuthActions();
     <!-- Mobile Menu Dropdown -->
     <div
       v-if="mobileMenuOpen && isAuth0Configured && loggedIn"
-      class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-stone-900 rounded-lg border border-violet-200 dark:border-stone-700 shadow-lg"
+      class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-slate-800 rounded-lg border border-violet-200 dark:border-slate-700 shadow-lg"
     >
       <!-- Welcome Message -->
-      <div class="mb-4 pb-4 border-b border-violet-200 dark:border-stone-700">
+      <div class="mb-4 pb-4 border-b border-violet-200 dark:border-slate-700">
         <div class="flex items-center space-x-3">
           <div
-            class="w-10 h-10 rounded-full bg-white dark:bg-stone-800 border-2 border-green-500 flex items-center justify-center relative"
+            class="w-10 h-10 rounded-full bg-white dark:bg-slate-700 border-2 border-green-500 flex items-center justify-center relative"
           >
             <UserIcon class="w-6 h-6 text-green-500" />
             <BadgeCheck
-              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-stone-800 rounded-full"
+              class="absolute -top-1 -right-1 w-4 h-4 text-green-500 bg-white dark:bg-slate-700 rounded-full"
             />
           </div>
           <div>
-            <p class="text-sm font-semibold text-gray-900 dark:text-stone-100">
+            <p class="text-sm font-semibold text-gray-900 dark:text-slate-100">
               {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
             </p>
             <p
               v-if="(user as User)?.roles?.length"
-              class="text-xs text-gray-500 dark:text-stone-400"
+              class="text-xs text-gray-500 dark:text-slate-400"
             >
               {{
                 (user as User)?.roles
@@ -250,10 +250,10 @@ const { login, logout } = useAuthActions();
         v-if="isAdmin"
         to="/admin/users"
         @click="mobileMenuOpen = false"
-        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-stone-800 transition-colors mb-2"
+        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-slate-700 transition-colors mb-2"
       >
-        <Users class="w-5 h-5 text-gray-600 dark:text-stone-300" />
-        <span class="text-sm text-gray-700 dark:text-stone-200">{{
+        <Users class="w-5 h-5 text-gray-600 dark:text-slate-300" />
+        <span class="text-sm text-gray-700 dark:text-slate-200">{{
           t("auth.userManagement")
         }}</span>
       </NuxtLink>

--- a/components/shared/GlassCard.vue
+++ b/components/shared/GlassCard.vue
@@ -14,13 +14,19 @@ const props = defineProps<{
 
 <style scoped>
 .glass-card {
-  background-color: rgb(255 255 255 / 0.6);
-  border: 1px solid rgb(255 255 255 / 0.42);
+  background-color: var(--glass-bg, rgb(255 255 255 / 0.6));
+  border: 1px solid var(--glass-border, rgb(255 255 255 / 0.42));
   box-shadow:
-    0 1px 0 rgb(255 255 255 / 0.45) inset,
+    0 1px 0 var(--glass-highlight, rgb(255 255 255 / 0.45)) inset,
     0 24px 56px -16px rgb(28 25 23 / 0.32),
     0 12px 24px -12px rgb(28 25 23 / 0.14);
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
+}
+
+html.dark .glass-card {
+  --glass-bg: rgb(28 25 23 / 0.55);
+  --glass-border: rgb(255 255 255 / 0.08);
+  --glass-highlight: rgb(255 255 255 / 0.06);
 }
 </style>

--- a/components/shared/GlassCard.vue
+++ b/components/shared/GlassCard.vue
@@ -25,7 +25,7 @@ const props = defineProps<{
 }
 
 html.dark .glass-card {
-  --glass-bg: rgb(28 25 23 / 0.55);
+  --glass-bg: rgb(30 41 59 / 0.55);
   --glass-border: rgb(255 255 255 / 0.08);
   --glass-highlight: rgb(255 255 255 / 0.06);
 }

--- a/components/shared/GlassCard.vue
+++ b/components/shared/GlassCard.vue
@@ -25,7 +25,7 @@ const props = defineProps<{
 }
 
 html.dark .glass-card {
-  --glass-bg: rgb(30 41 59 / 0.55);
+  --glass-bg: rgb(28 24 48 / 0.55);
   --glass-border: rgb(255 255 255 / 0.08);
   --glass-highlight: rgb(255 255 255 / 0.06);
 }

--- a/components/shared/GlobeLanguagePicker.vue
+++ b/components/shared/GlobeLanguagePicker.vue
@@ -69,12 +69,12 @@ const dropdownClasses = computed(() => {
     case "hero":
       return "origin-top-right absolute right-0 z-50 mt-2 w-56 rounded-xl border border-white/25 bg-stone-900/90 py-1 shadow-xl shadow-stone-950/40 ring-1 ring-white/10 backdrop-blur-xl";
     case "white":
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-stone-800 ring-1 ring-black ring-opacity-5 dark:ring-stone-700 z-50";
     case "dark":
       return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-gray-800 ring-1 ring-gray-600 z-50";
     case "violet":
     default:
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-gray-200 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-stone-800 ring-1 ring-gray-200 dark:ring-stone-700 z-50";
   }
 });
 
@@ -83,22 +83,21 @@ const itemClasses = computed(() => {
     case "hero":
       return "block px-4 py-2 text-sm text-stone-100 transition-colors hover:bg-white/15";
     case "white":
-      return "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-stone-200 hover:bg-gray-100 dark:hover:bg-stone-700 transition-colors";
     case "dark":
       return "block px-4 py-2 text-sm text-white hover:bg-gray-700 transition-colors";
     case "violet":
     default:
-      return "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-stone-200 hover:bg-gray-100 dark:hover:bg-stone-700 transition-colors";
   }
 });
 
-// Mobile item classes
 const mobileItemClasses = computed(() => {
   return (langCode: string) => [
     "w-full text-left px-4 py-2 rounded-lg text-sm transition-colors",
     locale.value === langCode
-      ? "bg-violet-100 text-violet-700 font-medium"
-      : "text-gray-700 hover:bg-violet-50",
+      ? "bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-200 font-medium"
+      : "text-gray-700 dark:text-stone-200 hover:bg-violet-50 dark:hover:bg-stone-800",
   ];
 });
 </script>
@@ -116,14 +115,16 @@ const mobileItemClasses = computed(() => {
           'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
           theme === 'hero'
             ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
-            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2',
+            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-stone-800 dark:hover:bg-stone-700 dark:focus:ring-offset-stone-900',
         ]"
         @click.stop="dropdownOpen = !dropdownOpen"
       >
         <Globe
           :class="[
             'h-5 w-5',
-            theme === 'hero' ? 'text-white' : 'text-gray-600',
+            theme === 'hero'
+              ? 'text-white'
+              : 'text-gray-600 dark:text-stone-300',
           ]"
         />
       </button>
@@ -151,16 +152,16 @@ const mobileItemClasses = computed(() => {
   <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
     <button
       @click="toggleLanguagePicker"
-      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 rounded-lg px-2 py-2 transition-colors"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-stone-800 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
-        <Globe class="w-5 h-5 text-gray-600" />
-        <span class="text-sm text-gray-700 font-medium">{{
+        <Globe class="w-5 h-5 text-gray-600 dark:text-stone-300" />
+        <span class="text-sm text-gray-700 dark:text-stone-200 font-medium">{{
           t("header.languagePicker")
         }}</span>
       </div>
       <ChevronDown
-        class="w-4 h-4 text-gray-600 transition-transform"
+        class="w-4 h-4 text-gray-600 dark:text-stone-300 transition-transform"
         :class="{ 'rotate-180': languagePickerOpen }"
       />
     </button>

--- a/components/shared/GlobeLanguagePicker.vue
+++ b/components/shared/GlobeLanguagePicker.vue
@@ -69,12 +69,12 @@ const dropdownClasses = computed(() => {
     case "hero":
       return "origin-top-right absolute right-0 z-50 mt-2 w-56 rounded-xl border border-white/25 bg-stone-900/90 py-1 shadow-xl shadow-stone-950/40 ring-1 ring-white/10 backdrop-blur-xl";
     case "white":
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-slate-700 ring-1 ring-black ring-opacity-5 dark:ring-slate-700 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-dusk-700 ring-1 ring-black ring-opacity-5 dark:ring-dusk-700 z-50";
     case "dark":
       return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-gray-800 ring-1 ring-gray-600 z-50";
     case "violet":
     default:
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-slate-700 ring-1 ring-gray-200 dark:ring-slate-700 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-dusk-700 ring-1 ring-gray-200 dark:ring-dusk-700 z-50";
   }
 });
 
@@ -83,12 +83,12 @@ const itemClasses = computed(() => {
     case "hero":
       return "block px-4 py-2 text-sm text-stone-100 transition-colors hover:bg-white/15";
     case "white":
-      return "block px-4 py-2 text-sm text-gray-700 dark:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-600 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-dusk-200 hover:bg-gray-100 dark:hover:bg-dusk-600 transition-colors";
     case "dark":
       return "block px-4 py-2 text-sm text-white hover:bg-gray-700 transition-colors";
     case "violet":
     default:
-      return "block px-4 py-2 text-sm text-gray-700 dark:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-600 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-dusk-200 hover:bg-gray-100 dark:hover:bg-dusk-600 transition-colors";
   }
 });
 
@@ -97,7 +97,7 @@ const mobileItemClasses = computed(() => {
     "w-full text-left px-4 py-2 rounded-lg text-sm transition-colors",
     locale.value === langCode
       ? "bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-200 font-medium"
-      : "text-gray-700 dark:text-slate-200 hover:bg-violet-50 dark:hover:bg-slate-700",
+      : "text-gray-700 dark:text-dusk-200 hover:bg-violet-50 dark:hover:bg-dusk-700",
   ];
 });
 </script>
@@ -115,7 +115,7 @@ const mobileItemClasses = computed(() => {
           'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
           theme === 'hero'
             ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
-            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-slate-700 dark:hover:bg-slate-600 dark:focus:ring-offset-slate-800',
+            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-dusk-700 dark:hover:bg-dusk-600 dark:focus:ring-offset-dusk-800',
         ]"
         @click.stop="dropdownOpen = !dropdownOpen"
       >
@@ -124,7 +124,7 @@ const mobileItemClasses = computed(() => {
             'h-5 w-5',
             theme === 'hero'
               ? 'text-white'
-              : 'text-gray-600 dark:text-slate-300',
+              : 'text-gray-600 dark:text-dusk-300',
           ]"
         />
       </button>
@@ -152,16 +152,16 @@ const mobileItemClasses = computed(() => {
   <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
     <button
       @click="toggleLanguagePicker"
-      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-slate-700 rounded-lg px-2 py-2 transition-colors"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-dusk-700 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
-        <Globe class="w-5 h-5 text-gray-600 dark:text-slate-300" />
-        <span class="text-sm text-gray-700 dark:text-slate-200 font-medium">{{
+        <Globe class="w-5 h-5 text-gray-600 dark:text-dusk-300" />
+        <span class="text-sm text-gray-700 dark:text-dusk-200 font-medium">{{
           t("header.languagePicker")
         }}</span>
       </div>
       <ChevronDown
-        class="w-4 h-4 text-gray-600 dark:text-slate-300 transition-transform"
+        class="w-4 h-4 text-gray-600 dark:text-dusk-300 transition-transform"
         :class="{ 'rotate-180': languagePickerOpen }"
       />
     </button>

--- a/components/shared/GlobeLanguagePicker.vue
+++ b/components/shared/GlobeLanguagePicker.vue
@@ -69,12 +69,12 @@ const dropdownClasses = computed(() => {
     case "hero":
       return "origin-top-right absolute right-0 z-50 mt-2 w-56 rounded-xl border border-white/25 bg-stone-900/90 py-1 shadow-xl shadow-stone-950/40 ring-1 ring-white/10 backdrop-blur-xl";
     case "white":
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-stone-800 ring-1 ring-black ring-opacity-5 dark:ring-stone-700 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-slate-700 ring-1 ring-black ring-opacity-5 dark:ring-slate-700 z-50";
     case "dark":
       return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-gray-800 ring-1 ring-gray-600 z-50";
     case "violet":
     default:
-      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-stone-800 ring-1 ring-gray-200 dark:ring-stone-700 z-50";
+      return "origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-slate-700 ring-1 ring-gray-200 dark:ring-slate-700 z-50";
   }
 });
 
@@ -83,12 +83,12 @@ const itemClasses = computed(() => {
     case "hero":
       return "block px-4 py-2 text-sm text-stone-100 transition-colors hover:bg-white/15";
     case "white":
-      return "block px-4 py-2 text-sm text-gray-700 dark:text-stone-200 hover:bg-gray-100 dark:hover:bg-stone-700 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-600 transition-colors";
     case "dark":
       return "block px-4 py-2 text-sm text-white hover:bg-gray-700 transition-colors";
     case "violet":
     default:
-      return "block px-4 py-2 text-sm text-gray-700 dark:text-stone-200 hover:bg-gray-100 dark:hover:bg-stone-700 transition-colors";
+      return "block px-4 py-2 text-sm text-gray-700 dark:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-600 transition-colors";
   }
 });
 
@@ -97,7 +97,7 @@ const mobileItemClasses = computed(() => {
     "w-full text-left px-4 py-2 rounded-lg text-sm transition-colors",
     locale.value === langCode
       ? "bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-200 font-medium"
-      : "text-gray-700 dark:text-stone-200 hover:bg-violet-50 dark:hover:bg-stone-800",
+      : "text-gray-700 dark:text-slate-200 hover:bg-violet-50 dark:hover:bg-slate-700",
   ];
 });
 </script>
@@ -115,7 +115,7 @@ const mobileItemClasses = computed(() => {
           'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
           theme === 'hero'
             ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
-            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-stone-800 dark:hover:bg-stone-700 dark:focus:ring-offset-stone-900',
+            : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-slate-700 dark:hover:bg-slate-600 dark:focus:ring-offset-slate-800',
         ]"
         @click.stop="dropdownOpen = !dropdownOpen"
       >
@@ -124,7 +124,7 @@ const mobileItemClasses = computed(() => {
             'h-5 w-5',
             theme === 'hero'
               ? 'text-white'
-              : 'text-gray-600 dark:text-stone-300',
+              : 'text-gray-600 dark:text-slate-300',
           ]"
         />
       </button>
@@ -152,16 +152,16 @@ const mobileItemClasses = computed(() => {
   <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
     <button
       @click="toggleLanguagePicker"
-      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-stone-800 rounded-lg px-2 py-2 transition-colors"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-slate-700 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
-        <Globe class="w-5 h-5 text-gray-600 dark:text-stone-300" />
-        <span class="text-sm text-gray-700 dark:text-stone-200 font-medium">{{
+        <Globe class="w-5 h-5 text-gray-600 dark:text-slate-300" />
+        <span class="text-sm text-gray-700 dark:text-slate-200 font-medium">{{
           t("header.languagePicker")
         }}</span>
       </div>
       <ChevronDown
-        class="w-4 h-4 text-gray-600 dark:text-stone-300 transition-transform"
+        class="w-4 h-4 text-gray-600 dark:text-slate-300 transition-transform"
         :class="{ 'rotate-180': languagePickerOpen }"
       />
     </button>

--- a/components/shared/HeaderBrand.vue
+++ b/components/shared/HeaderBrand.vue
@@ -16,7 +16,7 @@ import { Layers } from "lucide-vue-next";
       class="min-w-0 shrink rounded-lg py-2 max-[1000px]:px-2 min-[1001px]:px-4"
     >
       <h1
-        class="m-0 font-bold leading-tight text-stone-900 dark:text-stone-100 max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
+        class="m-0 font-bold leading-tight text-stone-900 dark:text-slate-100 max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
       >
         Guardian Connector
       </h1>

--- a/components/shared/HeaderBrand.vue
+++ b/components/shared/HeaderBrand.vue
@@ -16,7 +16,7 @@ import { Layers } from "lucide-vue-next";
       class="min-w-0 shrink rounded-lg py-2 max-[1000px]:px-2 min-[1001px]:px-4"
     >
       <h1
-        class="m-0 font-bold leading-tight text-stone-900 dark:text-slate-100 max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
+        class="m-0 font-bold leading-tight text-stone-900 dark:text-dusk-100 max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
       >
         Guardian Connector
       </h1>

--- a/components/shared/HeaderBrand.vue
+++ b/components/shared/HeaderBrand.vue
@@ -16,7 +16,7 @@ import { Layers } from "lucide-vue-next";
       class="min-w-0 shrink rounded-lg py-2 max-[1000px]:px-2 min-[1001px]:px-4"
     >
       <h1
-        class="m-0 font-bold leading-tight max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
+        class="m-0 font-bold leading-tight text-stone-900 dark:text-stone-100 max-[1000px]:text-sm min-[1001px]:text-lg min-[1001px]:max-[1200px]:text-xs"
       >
         Guardian Connector
       </h1>

--- a/components/shared/HoverTooltip.vue
+++ b/components/shared/HoverTooltip.vue
@@ -13,7 +13,7 @@ const tooltipId = useId();
     class="group relative inline-block max-w-full align-baseline text-inherit"
   >
     <span
-      class="cursor-help border-b border-dotted border-gray-500 outline-none"
+      class="cursor-help border-b border-dotted border-gray-500 dark:border-stone-400 outline-none"
       tabindex="0"
       :aria-describedby="tooltipId"
     >

--- a/components/shared/HoverTooltip.vue
+++ b/components/shared/HoverTooltip.vue
@@ -13,7 +13,7 @@ const tooltipId = useId();
     class="group relative inline-block max-w-full align-baseline text-inherit"
   >
     <span
-      class="cursor-help border-b border-dotted border-gray-500 dark:border-slate-400 outline-none"
+      class="cursor-help border-b border-dotted border-gray-500 dark:border-dusk-400 outline-none"
       tabindex="0"
       :aria-describedby="tooltipId"
     >

--- a/components/shared/HoverTooltip.vue
+++ b/components/shared/HoverTooltip.vue
@@ -13,7 +13,7 @@ const tooltipId = useId();
     class="group relative inline-block max-w-full align-baseline text-inherit"
   >
     <span
-      class="cursor-help border-b border-dotted border-gray-500 dark:border-stone-400 outline-none"
+      class="cursor-help border-b border-dotted border-gray-500 dark:border-slate-400 outline-none"
       tabindex="0"
       :aria-describedby="tooltipId"
     >

--- a/components/shared/ThemeToggle.vue
+++ b/components/shared/ThemeToggle.vue
@@ -32,7 +32,7 @@ const ariaLabel = computed(() =>
       'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
       props.theme === 'hero'
         ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
-        : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-stone-800 dark:hover:bg-stone-700 dark:focus:ring-offset-stone-900',
+        : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-slate-700 dark:hover:bg-slate-600 dark:focus:ring-offset-slate-800',
     ]"
     @click="toggleTheme"
   >
@@ -40,7 +40,7 @@ const ariaLabel = computed(() =>
       v-if="isDark"
       :class="[
         'h-5 w-5',
-        props.theme === 'hero' ? 'text-white' : 'text-stone-300',
+        props.theme === 'hero' ? 'text-white' : 'text-slate-300',
       ]"
     />
     <Moon
@@ -56,18 +56,18 @@ const ariaLabel = computed(() =>
   <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
     <button
       @click="toggleTheme"
-      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-stone-800 rounded-lg px-2 py-2 transition-colors"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-slate-700 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
         <component
           :is="isDark ? Sun : Moon"
-          class="w-5 h-5 text-gray-600 dark:text-stone-300"
+          class="w-5 h-5 text-gray-600 dark:text-slate-300"
         />
-        <span class="text-sm text-gray-700 dark:text-stone-200 font-medium">
+        <span class="text-sm text-gray-700 dark:text-slate-200 font-medium">
           {{ t("header.themeToggle") }}
         </span>
       </div>
-      <span class="text-xs text-gray-500 dark:text-stone-400">
+      <span class="text-xs text-gray-500 dark:text-slate-400">
         {{ isDark ? t("theme.dark") : t("theme.light") }}
       </span>
     </button>

--- a/components/shared/ThemeToggle.vue
+++ b/components/shared/ThemeToggle.vue
@@ -32,7 +32,7 @@ const ariaLabel = computed(() =>
       'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
       props.theme === 'hero'
         ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
-        : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-slate-700 dark:hover:bg-slate-600 dark:focus:ring-offset-slate-800',
+        : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-dusk-700 dark:hover:bg-dusk-600 dark:focus:ring-offset-dusk-800',
     ]"
     @click="toggleTheme"
   >
@@ -40,7 +40,7 @@ const ariaLabel = computed(() =>
       v-if="isDark"
       :class="[
         'h-5 w-5',
-        props.theme === 'hero' ? 'text-white' : 'text-slate-300',
+        props.theme === 'hero' ? 'text-white' : 'text-dusk-300',
       ]"
     />
     <Moon
@@ -56,18 +56,18 @@ const ariaLabel = computed(() =>
   <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
     <button
       @click="toggleTheme"
-      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-slate-700 rounded-lg px-2 py-2 transition-colors"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-dusk-700 rounded-lg px-2 py-2 transition-colors"
     >
       <div class="flex items-center space-x-3">
         <component
           :is="isDark ? Sun : Moon"
-          class="w-5 h-5 text-gray-600 dark:text-slate-300"
+          class="w-5 h-5 text-gray-600 dark:text-dusk-300"
         />
-        <span class="text-sm text-gray-700 dark:text-slate-200 font-medium">
+        <span class="text-sm text-gray-700 dark:text-dusk-200 font-medium">
           {{ t("header.themeToggle") }}
         </span>
       </div>
-      <span class="text-xs text-gray-500 dark:text-slate-400">
+      <span class="text-xs text-gray-500 dark:text-dusk-400">
         {{ isDark ? t("theme.dark") : t("theme.light") }}
       </span>
     </button>

--- a/components/shared/ThemeToggle.vue
+++ b/components/shared/ThemeToggle.vue
@@ -1,0 +1,75 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useI18n } from "#imports";
+import { Moon, Sun } from "lucide-vue-next";
+import { useTheme } from "@/composables/useTheme";
+
+interface Props {
+  theme?: "violet" | "white" | "hero";
+  variant?: "icon" | "mobile";
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  theme: "white",
+  variant: "icon",
+});
+
+const { t } = useI18n();
+const { isDark, toggleTheme } = useTheme();
+
+const ariaLabel = computed(() =>
+  isDark.value ? t("theme.switchToLight") : t("theme.switchToDark"),
+);
+</script>
+
+<template>
+  <!-- Desktop Icon Variant -->
+  <button
+    v-if="variant === 'icon'"
+    type="button"
+    :aria-label="ariaLabel"
+    :class="[
+      'relative flex h-10 w-10 items-center justify-center rounded-full transition-colors focus:outline-none',
+      props.theme === 'hero'
+        ? 'border border-white/40 bg-white/15 shadow-sm backdrop-blur-md hover:bg-white/25 focus-visible:ring-2 focus-visible:ring-white/50'
+        : 'bg-white hover:bg-gray-50 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:bg-stone-800 dark:hover:bg-stone-700 dark:focus:ring-offset-stone-900',
+    ]"
+    @click="toggleTheme"
+  >
+    <Sun
+      v-if="isDark"
+      :class="[
+        'h-5 w-5',
+        props.theme === 'hero' ? 'text-white' : 'text-stone-300',
+      ]"
+    />
+    <Moon
+      v-else
+      :class="[
+        'h-5 w-5',
+        props.theme === 'hero' ? 'text-white' : 'text-gray-600',
+      ]"
+    />
+  </button>
+
+  <!-- Mobile Variant -->
+  <div v-else-if="variant === 'mobile'" class="px-4 py-3 mb-2">
+    <button
+      @click="toggleTheme"
+      class="w-full flex items-center justify-between space-x-3 hover:bg-violet-50 dark:hover:bg-stone-800 rounded-lg px-2 py-2 transition-colors"
+    >
+      <div class="flex items-center space-x-3">
+        <component
+          :is="isDark ? Sun : Moon"
+          class="w-5 h-5 text-gray-600 dark:text-stone-300"
+        />
+        <span class="text-sm text-gray-700 dark:text-stone-200 font-medium">
+          {{ t("header.themeToggle") }}
+        </span>
+      </div>
+      <span class="text-xs text-gray-500 dark:text-stone-400">
+        {{ isDark ? t("theme.dark") : t("theme.light") }}
+      </span>
+    </button>
+  </div>
+</template>

--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -118,27 +118,27 @@ const formatDate = (dateString: string) => {
       >
         <!-- Background overlay -->
         <div
-          class="fixed inset-0 bg-gray-500 dark:bg-slate-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
+          class="fixed inset-0 bg-gray-500 dark:bg-dusk-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
           aria-hidden="true"
           @click="closeModal"
         ></div>
 
         <!-- Modal panel -->
         <div
-          class="relative inline-block align-bottom bg-white dark:bg-slate-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+          class="relative inline-block align-bottom bg-white dark:bg-dusk-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
         >
-          <div class="bg-white dark:bg-slate-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="bg-white dark:bg-dusk-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mt-3 sm:mt-0 text-left w-full">
                 <h3
-                  class="text-lg leading-6 font-medium text-gray-900 dark:text-slate-100 mb-4"
+                  class="text-lg leading-6 font-medium text-gray-900 dark:text-dusk-100 mb-4"
                   id="modal-title"
                 >
                   {{ t("userManagement.editUserTitle", { email: user.email }) }}
                 </h3>
 
                 <!-- User Info -->
-                <div class="mb-6 p-4 bg-gray-50 dark:bg-slate-700 rounded-lg">
+                <div class="mb-6 p-4 bg-gray-50 dark:bg-dusk-700 rounded-lg">
                   <div class="flex items-center mb-3">
                     <img
                       v-if="user.picture && !imageError"
@@ -156,7 +156,7 @@ const formatDate = (dateString: string) => {
                     />
                     <div>
                       <div
-                        class="text-sm font-medium text-gray-900 dark:text-slate-100"
+                        class="text-sm font-medium text-gray-900 dark:text-dusk-100"
                       >
                         {{
                           user.name ||
@@ -164,12 +164,12 @@ const formatDate = (dateString: string) => {
                           t("userManagement.unknown")
                         }}
                       </div>
-                      <div class="text-sm text-gray-500 dark:text-slate-400">
+                      <div class="text-sm text-gray-500 dark:text-dusk-400">
                         {{ user.email }}
                       </div>
                     </div>
                   </div>
-                  <div class="text-xs text-gray-500 dark:text-slate-400">
+                  <div class="text-xs text-gray-500 dark:text-dusk-400">
                     <div>
                       {{ t("userManagement.created") }}:
                       {{ formatDate(user.created_at) }}
@@ -190,14 +190,14 @@ const formatDate = (dateString: string) => {
                     <input
                       v-model="isApproved"
                       type="checkbox"
-                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-slate-700 rounded"
+                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-dusk-700 rounded"
                     />
                     <span
-                      class="ml-2 text-sm text-gray-700 dark:text-slate-300"
+                      class="ml-2 text-sm text-gray-700 dark:text-dusk-300"
                       >{{ t("userManagement.userIsApproved") }}</span
                     >
                   </label>
-                  <p class="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                  <p class="text-xs text-gray-500 dark:text-dusk-400 mt-1">
                     {{ t("userManagement.approvedUsersDescription") }}
                   </p>
                 </div>
@@ -205,12 +205,12 @@ const formatDate = (dateString: string) => {
                 <!-- Roles Selection -->
                 <div class="mb-6">
                   <label
-                    class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-3"
+                    class="block text-sm font-medium text-gray-700 dark:text-dusk-300 mb-3"
                   >
                     {{ t("userManagement.userRoles") }}
                   </label>
                   <div
-                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-slate-700 rounded-lg p-3"
+                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-dusk-700 rounded-lg p-3"
                   >
                     <div
                       v-for="role in availableRoles"
@@ -223,22 +223,22 @@ const formatDate = (dateString: string) => {
                         :value="role.id"
                         type="radio"
                         name="user-role"
-                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-slate-700 mt-0.5"
+                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-dusk-700 mt-0.5"
                       />
                       <div class="ml-3">
                         <label
                           :for="`role-${role.id}`"
-                          class="text-sm font-medium text-gray-700 dark:text-slate-300 cursor-pointer"
+                          class="text-sm font-medium text-gray-700 dark:text-dusk-300 cursor-pointer"
                         >
                           {{ translateRoleName(role.name, t) }}
                         </label>
-                        <p class="text-xs text-gray-500 dark:text-slate-400">
+                        <p class="text-xs text-gray-500 dark:text-dusk-400">
                           {{ translateRoleDescription(role.name, t) }}
                         </p>
                       </div>
                     </div>
                   </div>
-                  <p class="text-xs text-gray-500 dark:text-slate-400 mt-2">
+                  <p class="text-xs text-gray-500 dark:text-dusk-400 mt-2">
                     {{ t("userManagement.selectedRoles") }}:
                     {{ selectedRoleName }}
                   </p>
@@ -259,12 +259,12 @@ const formatDate = (dateString: string) => {
 
           <!-- Modal Actions -->
           <div
-            class="bg-gray-50 dark:bg-slate-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
+            class="bg-gray-50 dark:bg-dusk-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
           >
             <button
               @click="handleSave"
               :disabled="isSaving"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-700 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-700 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{
                 isSaving
@@ -275,7 +275,7 @@ const formatDate = (dateString: string) => {
             <button
               @click="closeModal"
               :disabled="isSaving"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-slate-700 shadow-sm px-4 py-2 bg-white dark:bg-slate-800 text-base font-medium text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-700 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-dusk-700 shadow-sm px-4 py-2 bg-white dark:bg-dusk-800 text-base font-medium text-gray-700 dark:text-dusk-200 hover:bg-gray-50 dark:hover:bg-dusk-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-700 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t("userManagement.cancel") }}
             </button>

--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -118,27 +118,27 @@ const formatDate = (dateString: string) => {
       >
         <!-- Background overlay -->
         <div
-          class="fixed inset-0 bg-gray-500 dark:bg-stone-950 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
+          class="fixed inset-0 bg-gray-500 dark:bg-slate-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
           aria-hidden="true"
           @click="closeModal"
         ></div>
 
         <!-- Modal panel -->
         <div
-          class="relative inline-block align-bottom bg-white dark:bg-stone-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+          class="relative inline-block align-bottom bg-white dark:bg-slate-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
         >
-          <div class="bg-white dark:bg-stone-900 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="bg-white dark:bg-slate-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mt-3 sm:mt-0 text-left w-full">
                 <h3
-                  class="text-lg leading-6 font-medium text-gray-900 dark:text-stone-100 mb-4"
+                  class="text-lg leading-6 font-medium text-gray-900 dark:text-slate-100 mb-4"
                   id="modal-title"
                 >
                   {{ t("userManagement.editUserTitle", { email: user.email }) }}
                 </h3>
 
                 <!-- User Info -->
-                <div class="mb-6 p-4 bg-gray-50 dark:bg-stone-800 rounded-lg">
+                <div class="mb-6 p-4 bg-gray-50 dark:bg-slate-700 rounded-lg">
                   <div class="flex items-center mb-3">
                     <img
                       v-if="user.picture && !imageError"
@@ -156,7 +156,7 @@ const formatDate = (dateString: string) => {
                     />
                     <div>
                       <div
-                        class="text-sm font-medium text-gray-900 dark:text-stone-100"
+                        class="text-sm font-medium text-gray-900 dark:text-slate-100"
                       >
                         {{
                           user.name ||
@@ -164,12 +164,12 @@ const formatDate = (dateString: string) => {
                           t("userManagement.unknown")
                         }}
                       </div>
-                      <div class="text-sm text-gray-500 dark:text-stone-400">
+                      <div class="text-sm text-gray-500 dark:text-slate-400">
                         {{ user.email }}
                       </div>
                     </div>
                   </div>
-                  <div class="text-xs text-gray-500 dark:text-stone-400">
+                  <div class="text-xs text-gray-500 dark:text-slate-400">
                     <div>
                       {{ t("userManagement.created") }}:
                       {{ formatDate(user.created_at) }}
@@ -190,14 +190,14 @@ const formatDate = (dateString: string) => {
                     <input
                       v-model="isApproved"
                       type="checkbox"
-                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-stone-700 rounded"
+                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-slate-700 rounded"
                     />
                     <span
-                      class="ml-2 text-sm text-gray-700 dark:text-stone-300"
+                      class="ml-2 text-sm text-gray-700 dark:text-slate-300"
                       >{{ t("userManagement.userIsApproved") }}</span
                     >
                   </label>
-                  <p class="text-xs text-gray-500 dark:text-stone-400 mt-1">
+                  <p class="text-xs text-gray-500 dark:text-slate-400 mt-1">
                     {{ t("userManagement.approvedUsersDescription") }}
                   </p>
                 </div>
@@ -205,12 +205,12 @@ const formatDate = (dateString: string) => {
                 <!-- Roles Selection -->
                 <div class="mb-6">
                   <label
-                    class="block text-sm font-medium text-gray-700 dark:text-stone-300 mb-3"
+                    class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-3"
                   >
                     {{ t("userManagement.userRoles") }}
                   </label>
                   <div
-                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-stone-700 rounded-lg p-3"
+                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-slate-700 rounded-lg p-3"
                   >
                     <div
                       v-for="role in availableRoles"
@@ -223,22 +223,22 @@ const formatDate = (dateString: string) => {
                         :value="role.id"
                         type="radio"
                         name="user-role"
-                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-stone-700 mt-0.5"
+                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-slate-700 mt-0.5"
                       />
                       <div class="ml-3">
                         <label
                           :for="`role-${role.id}`"
-                          class="text-sm font-medium text-gray-700 dark:text-stone-300 cursor-pointer"
+                          class="text-sm font-medium text-gray-700 dark:text-slate-300 cursor-pointer"
                         >
                           {{ translateRoleName(role.name, t) }}
                         </label>
-                        <p class="text-xs text-gray-500 dark:text-stone-400">
+                        <p class="text-xs text-gray-500 dark:text-slate-400">
                           {{ translateRoleDescription(role.name, t) }}
                         </p>
                       </div>
                     </div>
                   </div>
-                  <p class="text-xs text-gray-500 dark:text-stone-400 mt-2">
+                  <p class="text-xs text-gray-500 dark:text-slate-400 mt-2">
                     {{ t("userManagement.selectedRoles") }}:
                     {{ selectedRoleName }}
                   </p>
@@ -259,12 +259,12 @@ const formatDate = (dateString: string) => {
 
           <!-- Modal Actions -->
           <div
-            class="bg-gray-50 dark:bg-stone-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
+            class="bg-gray-50 dark:bg-slate-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
           >
             <button
               @click="handleSave"
               :disabled="isSaving"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-800 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-700 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{
                 isSaving
@@ -275,7 +275,7 @@ const formatDate = (dateString: string) => {
             <button
               @click="closeModal"
               :disabled="isSaving"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-stone-700 shadow-sm px-4 py-2 bg-white dark:bg-stone-900 text-base font-medium text-gray-700 dark:text-stone-200 hover:bg-gray-50 dark:hover:bg-stone-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-800 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-slate-700 shadow-sm px-4 py-2 bg-white dark:bg-slate-800 text-base font-medium text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-slate-700 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t("userManagement.cancel") }}
             </button>

--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -100,7 +100,7 @@ const formatDate = (dateString: string) => {
     <button
       @click="openModal"
       :disabled="saving"
-      class="text-violet-600 hover:text-violet-800 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      class="text-violet-600 dark:text-violet-300 hover:text-violet-800 dark:hover:text-violet-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {{ t("userManagement.edit") }}
     </button>
@@ -118,27 +118,27 @@ const formatDate = (dateString: string) => {
       >
         <!-- Background overlay -->
         <div
-          class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          class="fixed inset-0 bg-gray-500 dark:bg-stone-950 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
           aria-hidden="true"
           @click="closeModal"
         ></div>
 
         <!-- Modal panel -->
         <div
-          class="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+          class="relative inline-block align-bottom bg-white dark:bg-stone-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
         >
-          <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="bg-white dark:bg-stone-900 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
                 <h3
-                  class="text-lg leading-6 font-medium text-gray-900 mb-4"
+                  class="text-lg leading-6 font-medium text-gray-900 dark:text-stone-100 mb-4"
                   id="modal-title"
                 >
                   {{ t("userManagement.editUserTitle", { email: user.email }) }}
                 </h3>
 
                 <!-- User Info -->
-                <div class="mb-6 p-4 bg-gray-50 rounded-lg">
+                <div class="mb-6 p-4 bg-gray-50 dark:bg-stone-800 rounded-lg">
                   <div class="flex items-center mb-3">
                     <img
                       v-if="user.picture && !imageError"
@@ -155,17 +155,21 @@ const formatDate = (dateString: string) => {
                       class="rounded-full mr-3"
                     />
                     <div>
-                      <div class="text-sm font-medium text-gray-900">
+                      <div
+                        class="text-sm font-medium text-gray-900 dark:text-stone-100"
+                      >
                         {{
                           user.name ||
                           user.nickname ||
                           t("userManagement.unknown")
                         }}
                       </div>
-                      <div class="text-sm text-gray-500">{{ user.email }}</div>
+                      <div class="text-sm text-gray-500 dark:text-stone-400">
+                        {{ user.email }}
+                      </div>
                     </div>
                   </div>
-                  <div class="text-xs text-gray-500">
+                  <div class="text-xs text-gray-500 dark:text-stone-400">
                     <div>
                       {{ t("userManagement.created") }}:
                       {{ formatDate(user.created_at) }}
@@ -186,24 +190,27 @@ const formatDate = (dateString: string) => {
                     <input
                       v-model="isApproved"
                       type="checkbox"
-                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 rounded"
+                      class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-stone-700 rounded"
                     />
-                    <span class="ml-2 text-sm text-gray-700">{{
-                      t("userManagement.userIsApproved")
-                    }}</span>
+                    <span
+                      class="ml-2 text-sm text-gray-700 dark:text-stone-300"
+                      >{{ t("userManagement.userIsApproved") }}</span
+                    >
                   </label>
-                  <p class="text-xs text-gray-500 mt-1">
+                  <p class="text-xs text-gray-500 dark:text-stone-400 mt-1">
                     {{ t("userManagement.approvedUsersDescription") }}
                   </p>
                 </div>
 
                 <!-- Roles Selection -->
                 <div class="mb-6">
-                  <label class="block text-sm font-medium text-gray-700 mb-3">
+                  <label
+                    class="block text-sm font-medium text-gray-700 dark:text-stone-300 mb-3"
+                  >
                     {{ t("userManagement.userRoles") }}
                   </label>
                   <div
-                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 rounded-lg p-3"
+                    class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-stone-700 rounded-lg p-3"
                   >
                     <div
                       v-for="role in availableRoles"
@@ -216,22 +223,22 @@ const formatDate = (dateString: string) => {
                         :value="role.id"
                         type="radio"
                         name="user-role"
-                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 mt-0.5"
+                        class="h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 dark:border-stone-700 mt-0.5"
                       />
                       <div class="ml-3">
                         <label
                           :for="`role-${role.id}`"
-                          class="text-sm font-medium text-gray-700 cursor-pointer"
+                          class="text-sm font-medium text-gray-700 dark:text-stone-300 cursor-pointer"
                         >
                           {{ translateRoleName(role.name, t) }}
                         </label>
-                        <p class="text-xs text-gray-500">
+                        <p class="text-xs text-gray-500 dark:text-stone-400">
                           {{ translateRoleDescription(role.name, t) }}
                         </p>
                       </div>
                     </div>
                   </div>
-                  <p class="text-xs text-gray-500 mt-2">
+                  <p class="text-xs text-gray-500 dark:text-stone-400 mt-2">
                     {{ t("userManagement.selectedRoles") }}:
                     {{ selectedRoleName }}
                   </p>
@@ -240,20 +247,24 @@ const formatDate = (dateString: string) => {
                 <!-- Error Display -->
                 <div
                   v-if="saveError"
-                  class="mb-6 p-3 bg-red-50 border border-red-200 rounded-lg"
+                  class="mb-6 p-3 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg"
                 >
-                  <p class="text-sm text-red-600">{{ saveError }}</p>
+                  <p class="text-sm text-red-600 dark:text-red-300">
+                    {{ saveError }}
+                  </p>
                 </div>
               </div>
             </div>
           </div>
 
           <!-- Modal Actions -->
-          <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <div
+            class="bg-gray-50 dark:bg-stone-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
+          >
             <button
               @click="handleSave"
               :disabled="isSaving"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-violet-600 text-base font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-800 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{
                 isSaving
@@ -264,7 +275,7 @@ const formatDate = (dateString: string) => {
             <button
               @click="closeModal"
               :disabled="isSaving"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-stone-700 shadow-sm px-4 py-2 bg-white dark:bg-stone-900 text-base font-medium text-gray-700 dark:text-stone-200 hover:bg-gray-50 dark:hover:bg-stone-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-stone-800 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ t("userManagement.cancel") }}
             </button>

--- a/composables/useTheme.ts
+++ b/composables/useTheme.ts
@@ -1,0 +1,24 @@
+import { computed } from "vue";
+import { useCookie } from "#imports";
+
+export type ColorMode = "light" | "dark";
+
+export const useTheme = () => {
+  const theme = useCookie<ColorMode>("color-mode", {
+    default: () => "light",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 365,
+  });
+
+  const isDark = computed(() => theme.value === "dark");
+
+  const setTheme = (next: ColorMode) => {
+    theme.value = next;
+  };
+
+  const toggleTheme = () => {
+    theme.value = isDark.value ? "light" : "dark";
+  };
+
+  return { theme, isDark, setTheme, toggleTheme };
+};

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -25,7 +25,14 @@
   },
   "header": {
     "adminAccess": "Admin Access",
-    "languagePicker": "Language Picker"
+    "languagePicker": "Language Picker",
+    "themeToggle": "Theme"
+  },
+  "theme": {
+    "light": "Light",
+    "dark": "Dark",
+    "switchToLight": "Switch to light mode",
+    "switchToDark": "Switch to dark mode"
   },
   "roles": {
     "admin": "Admin",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -48,7 +48,14 @@
   },
   "header": {
     "adminAccess": "Acceso de Administrador",
-    "languagePicker": "Selector de Idioma"
+    "languagePicker": "Selector de Idioma",
+    "themeToggle": "Tema"
+  },
+  "theme": {
+    "light": "Claro",
+    "dark": "Oscuro",
+    "switchToLight": "Cambiar a modo claro",
+    "switchToDark": "Cambiar a modo oscuro"
   },
   "roles": {
     "admin": "Administrador",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -48,7 +48,14 @@
   },
   "header": {
     "adminAccess": "Beheerders Toegang",
-    "languagePicker": "Taal Selector"
+    "languagePicker": "Taal Selector",
+    "themeToggle": "Thema"
+  },
+  "theme": {
+    "light": "Licht",
+    "dark": "Donker",
+    "switchToLight": "Schakel naar lichte modus",
+    "switchToDark": "Schakel naar donkere modus"
   },
   "roles": {
     "admin": "Beheerder",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -48,7 +48,14 @@
   },
   "header": {
     "adminAccess": "Acesso de Administrador",
-    "languagePicker": "Seletor de Idioma"
+    "languagePicker": "Seletor de Idioma",
+    "themeToggle": "Tema"
+  },
+  "theme": {
+    "light": "Claro",
+    "dark": "Escuro",
+    "switchToLight": "Mudar para o modo claro",
+    "switchToDark": "Mudar para o modo escuro"
   },
   "roles": {
     "admin": "Administrador",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -25,7 +25,14 @@
   },
   "header": {
     "adminAccess": "Ufikiaji wa Msimamizi",
-    "languagePicker": "Chagua lugha"
+    "languagePicker": "Chagua lugha",
+    "themeToggle": "Mandhari"
+  },
+  "theme": {
+    "light": "Mwangaza",
+    "dark": "Giza",
+    "switchToLight": "Badilisha kuwa hali ya mwanga",
+    "switchToDark": "Badilisha kuwa hali ya giza"
   },
   "roles": {
     "admin": "Msimamizi",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -48,7 +48,14 @@
   },
   "header": {
     "adminAccess": "การเข้าถึงผู้ดูแล",
-    "languagePicker": "เลือกภาษา"
+    "languagePicker": "เลือกภาษา",
+    "themeToggle": "ธีม"
+  },
+  "theme": {
+    "light": "สว่าง",
+    "dark": "มืด",
+    "switchToLight": "เปลี่ยนเป็นโหมดสว่าง",
+    "switchToDark": "เปลี่ยนเป็นโหมดมืด"
   },
   "roles": {
     "admin": "ผู้ดูแล",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,7 +3,7 @@ import AppHeader from "@/components/shared/AppHeader.vue";
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-white">
+  <div class="min-h-screen flex flex-col bg-white dark:bg-stone-950">
     <AppHeader />
     <slot></slot>
   </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,7 +3,7 @@ import AppHeader from "@/components/shared/AppHeader.vue";
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-white dark:bg-stone-950">
+  <div class="min-h-screen flex flex-col bg-white dark:bg-slate-900">
     <AppHeader />
     <slot></slot>
   </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,7 +3,7 @@ import AppHeader from "@/components/shared/AppHeader.vue";
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-white dark:bg-slate-900">
+  <div class="min-h-screen flex flex-col bg-white dark:bg-dusk-900">
     <AppHeader />
     <slot></slot>
   </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,5 @@
+import type { Config } from "tailwindcss";
+
+export default <Partial<Config>>{
+  darkMode: "class",
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,4 +2,27 @@ import type { Config } from "tailwindcss";
 
 export default <Partial<Config>>{
   darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        // Twilight-tinted neutral. Hue ~250 (between indigo and violet),
+        // low saturation so it reads as a neutral surface rather than "purple",
+        // matched in luminance to Tailwind `slate` so existing elevation steps
+        // (body 900 / card 800 / raised 700 / hover 600) still hold.
+        dusk: {
+          50: "#f5f3fb",
+          100: "#e6e2f3",
+          200: "#c8c1e0",
+          300: "#a299c4",
+          400: "#786e9e",
+          500: "#574e7a",
+          600: "#3f3957",
+          700: "#2a2640",
+          800: "#1c1830",
+          900: "#131022",
+          950: "#08060f",
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Goal

Is this crazy?!? 

Me personally, I pick dark mode every time for every app, and I _always_ find myself wanting this when I'm working on Guardian Connector on a plane. But at the very least, one of our power users (at `C***P`) has told me that they prefer dark mode over light, so there is at least one user in a partner organization that would welcome this.

Mind you, I don't think the current set of colors suit the overall aesthetics of Guardian Connector at all. But the same is maybe true of light mode, and the color scheme of GC is still an undecided thing! Like, we don't have a style or branding guide to begin with. But this dark mode implementation can surely adapted to fit a future color scheme, much like the light mode one could. And maybe this is stepping us in the direction of custom "skinning" for future partners as we've discussed for `C***B`? 

(I guess a different way of asking the question -- _is **any** type of dark mode even appropriate for Guardian Connector to begin with?_ Anyone reading, feel free to challenge this.) 

@nicopace @maypontes @luandro curious to your thoughts :)

## Screenshots

<img width="1164" height="977" alt="image" src="https://github.com/user-attachments/assets/4c3051fe-4f22-458b-a2dd-7d583e3c5665" />

<img width="1164" height="977" alt="image" src="https://github.com/user-attachments/assets/d3490b6e-ec00-4d75-ba32-db2910b2205d" />

<img width="1164" height="977" alt="image" src="https://github.com/user-attachments/assets/ef9bf999-377d-4cbd-a869-c6cfb848a192" />

<img width="529" height="937" alt="image" src="https://github.com/user-attachments/assets/f958f4d8-df43-42c6-89a6-e040ea150e2b" />

## What I changed and why

- Add `useTheme` composable to handle the toggle switch.
- Add a `ThemeToggle.vue` component to allow the user to switch in the app header.
- Implement Tailwind and CSS rules everywhere.

## What I'm not doing here

Touching GC Explorer, clearly. Thought to first trial and vet this on the simpler Nuxt.js UI that we maintain.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Claude Opus 4.7 in Cursor did all of this, but only after I ran Plan mode.