### PR TITLE
Return user last logged in timestamp in `dd/MM/yyyy HH:mm` format

### DIFF
--- a/components/UserManagement.vue
+++ b/components/UserManagement.vue
@@ -162,9 +162,15 @@ const handlePageChange = (page: number) => {
   fetchUsers(page);
 };
 
+/**
+ * Returns a local-time timestamp formatted as `dd/MM/yyyy HH:mm`.
+ * Falls back to the localized `"userManagement.never"` label when empty.
+ */
 const formatDate = (dateString: string) => {
   if (!dateString) return t("userManagement.never");
-  return new Date(dateString).toLocaleDateString();
+  const d = new Date(dateString);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 };
 
 const handleImageError = (userId: string) => {


### PR DESCRIPTION
## Goal

Closes #81.

## Screenshots

<img width="490" height="113" alt="image" src="https://github.com/user-attachments/assets/9ebb0591-666c-46b6-886f-8f6e01171749" />

## What I changed and why

Used JS `Date` data type to extract better timestamp info and have `formatDate` return a dd/MM/yyyy HH:mm format.

Note that I also switched from `MM/dd/yyyy` to `dd/MM/yyyy` because I think the latter is more common internationally.