### PR TITLE
Add computed to sort roles

### DIFF
--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -56,12 +56,6 @@ const sortedRoles = computed(() =>
   ),
 );
 
-const selectedRoleName = computed(() => {
-  if (!selectedRole.value) return t("userManagement.none");
-  const role = props.availableRoles.find((r) => r.id === selectedRole.value);
-  return role ? translateRoleName(role.name, t) : t("userManagement.unknown");
-});
-
 // Methods
 const openModal = () => {
   selectedRole.value = props.user.roles[0]?.id || "";

--- a/components/userManagement/UserEditModal.vue
+++ b/components/userManagement/UserEditModal.vue
@@ -41,7 +41,21 @@ const saveError = ref("");
 
 const isBusy = computed(() => isSaving.value || isRemoving.value);
 
+const ROLE_ORDER: Record<string, number> = {
+  Admin: 0,
+  Member: 1,
+  Guest: 2,
+  SignedIn: 3,
+};
+
 // Computed properties
+const sortedRoles = computed(() =>
+  [...props.availableRoles].sort(
+    (a, b) =>
+      (ROLE_ORDER[a.name] ?? Infinity) - (ROLE_ORDER[b.name] ?? Infinity),
+  ),
+);
+
 const selectedRoleName = computed(() => {
   if (!selectedRole.value) return t("userManagement.none");
   const role = props.availableRoles.find((r) => r.id === selectedRole.value);
@@ -251,7 +265,7 @@ const formatDate = (dateString: string) => {
                     class="space-y-2 max-h-48 overflow-y-auto border border-gray-200 dark:border-dusk-700 rounded-lg p-3"
                   >
                     <div
-                      v-for="role in availableRoles"
+                      v-for="role in sortedRoles"
                       :key="role.id"
                       class="flex items-start"
                     >


### PR DESCRIPTION
## Goal

I noticed that the current list of roles is unsorted, and presented in the order created on auth0. And on some communities, "Guest" appears before "Member". I think the sort should be in order of permissions elevation. So this PR sorts them accordingly.

I've also sought fit to remove a `selectedRolename` computed that is no longer in use.

## Screenshots

<img width="482" height="244" alt="image" src="https://github.com/user-attachments/assets/c880b7f8-5901-484e-beb8-34d34aa70d0a" />

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None
