### PR TITLE
Add theme settings route for logo and background image customization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,12 +6,6 @@ NUXT_OAUTH_AUTH0_CLIENT_SECRET=
 NUXT_OAUTH_AUTH0_CLIENT_ID=
 NUXT_OAUTH_AUTH0_DOMAIN=
 
-# optional: Community Logo URL
-NUXT_PUBLIC_LOGO_URL=
-
-# optional: Login page background image URL or path (falls back to public/background.jpg if not set)
-NUXT_PUBLIC_BACKGROUND_IMAGE=
-
 # optional: Domain (falls back to guardianconnector.net if not set)
 NUXT_PUBLIC_DOMAIN=
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ Local deployment of Docker:
 docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 ```
 
-## Login page
-
-- **Background image** — By default the sign-in page uses [`public/background.jpg`](public/background.jpg). Override it in **Theme Settings** (Admin → Theme) via the Background Image URL stored in `gc_settings`.
-
 ## Authentication
 
 ### Auth0 Setup

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 
 ## Login page
 
-- **Background image** — By default the sign-in page uses [`public/background.jpg`](public/background.jpg). To override it, set **`NUXT_PUBLIC_BACKGROUND_IMAGE`** to a full image URL. Leave unset to keep the default asset.
+- **Background image** — By default the sign-in page uses [`public/background.jpg`](public/background.jpg). Override it in **Theme Settings** (Admin → Theme) via the Background Image URL stored in `gc_settings`.
 
 ## Authentication
 

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -3,6 +3,7 @@ import { useRuntimeConfig } from "#imports";
 import HoverTooltip from "@/components/shared/HoverTooltip.vue";
 import ServicesGrid from "@/components/homepage/ServicesGrid.vue";
 import DataSourcesGrid from "@/components/homepage/DataSourcesGrid.vue";
+import { useThemeSettings } from "@/composables/useThemeSettings";
 import { Workflow } from "lucide-vue-next";
 
 const props = defineProps<{
@@ -11,13 +12,13 @@ const props = defineProps<{
   shouldShowApp: boolean;
 }>();
 
-const emit = defineEmits<{
+defineEmits<{
   login: [];
 }>();
 
 const config = useRuntimeConfig();
 const communityName = config.public.communityName;
-const logoUrl = config.public.logoUrl as string | undefined;
+const { logoUrl } = useThemeSettings();
 const { t } = useI18n();
 </script>
 

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -3,6 +3,7 @@ import { useUserSession, onMounted } from "#imports";
 import GlassCard from "@/components/shared/GlassCard.vue";
 import GlobeLanguagePicker from "@/components/shared/GlobeLanguagePicker.vue";
 import SponsorLogos from "@/components/SponsorLogos.vue";
+import { useThemeSettings } from "@/composables/useThemeSettings";
 
 interface Props {
   errorMessage: string;
@@ -10,11 +11,7 @@ interface Props {
 const props = defineProps<Props>();
 const { loggedIn } = useUserSession();
 const { t } = useI18n();
-const runtimeConfig = useRuntimeConfig();
-const loginBackgroundSrc = computed(() => {
-  const url = String(runtimeConfig.public.backgroundImage ?? "").trim();
-  return url || "/background.jpg";
-});
+const { backgroundImage: loginBackgroundSrc } = useThemeSettings();
 const loginWithAuth0 = () => {
   window.location.href = "/api/auth/auth0";
 };

--- a/components/ThemeSettings.vue
+++ b/components/ThemeSettings.vue
@@ -10,18 +10,23 @@ import {
   Sparkles,
   XCircle,
 } from "lucide-vue-next";
+import {
+  THEME_SETTING_KEYS,
+  emptyThemeSettings,
+  type ThemeSettingKey,
+  type ThemeSettingsMap,
+} from "~/utils/themeSettings";
 
-type ThemeKey = "logo_url" | "background_image";
 type FieldStatus = "idle" | "saving" | "saved" | "error";
 
 interface ThemeSettingsResponse {
   success: boolean;
-  settings: Record<ThemeKey, string>;
+  settings: ThemeSettingsMap;
 }
 
 interface ThemeSaveResponse {
   success: boolean;
-  key: ThemeKey;
+  key: ThemeSettingKey;
   value: string;
 }
 
@@ -33,43 +38,33 @@ const { t } = useI18n();
 const loading = ref(true);
 const loadError = ref("");
 
-const fields = reactive<Record<ThemeKey, string>>({
-  logo_url: "",
-  background_image: "",
-});
+const fields = reactive(emptyThemeSettings());
+const saved = reactive(emptyThemeSettings());
+const status = reactive(
+  Object.fromEntries(
+    THEME_SETTING_KEYS.map((key) => [key, "idle" as FieldStatus]),
+  ) as Record<ThemeSettingKey, FieldStatus>,
+);
+const fieldErrors = reactive(emptyThemeSettings());
 
-const saved = reactive<Record<ThemeKey, string>>({
-  logo_url: "",
-  background_image: "",
-});
-
-const status = reactive<Record<ThemeKey, FieldStatus>>({
-  logo_url: "idle",
-  background_image: "idle",
-});
-
-const fieldErrors = reactive<Record<ThemeKey, string>>({
-  logo_url: "",
-  background_image: "",
-});
-
-const debounceTimers: Partial<Record<ThemeKey, ReturnType<typeof setTimeout>>> =
-  {};
-const savedFlashTimers: Partial<
-  Record<ThemeKey, ReturnType<typeof setTimeout>>
+const debounceTimers: Partial<
+  Record<ThemeSettingKey, ReturnType<typeof setTimeout>>
 > = {};
-const inFlight = new Map<ThemeKey, number>();
+const savedFlashTimers: Partial<
+  Record<ThemeSettingKey, ReturnType<typeof setTimeout>>
+> = {};
+const inFlight = new Map<ThemeSettingKey, number>();
 
 const fieldDefs = computed(() => [
   {
-    key: "logo_url" as const,
+    key: "logo_url" satisfies ThemeSettingKey,
     label: t("themeSettings.logoUrl"),
     hint: t("themeSettings.logoUrlHint"),
     placeholder: t("themeSettings.logoUrlPlaceholder"),
     icon: Sparkles,
   },
   {
-    key: "background_image" as const,
+    key: "background_image" satisfies ThemeSettingKey,
     label: t("themeSettings.backgroundImage"),
     hint: t("themeSettings.backgroundImageHint"),
     placeholder: t("themeSettings.backgroundImagePlaceholder"),
@@ -78,15 +73,13 @@ const fieldDefs = computed(() => [
 ]);
 
 const clearTimers = () => {
-  for (const key of Object.keys(debounceTimers) as ThemeKey[]) {
+  for (const key of THEME_SETTING_KEYS) {
     clearTimeout(debounceTimers[key]);
-  }
-  for (const key of Object.keys(savedFlashTimers) as ThemeKey[]) {
     clearTimeout(savedFlashTimers[key]);
   }
 };
 
-const flashSaved = (key: ThemeKey) => {
+const flashSaved = (key: ThemeSettingKey) => {
   status[key] = "saved";
   clearTimeout(savedFlashTimers[key]);
   savedFlashTimers[key] = setTimeout(() => {
@@ -94,7 +87,7 @@ const flashSaved = (key: ThemeKey) => {
   }, SAVED_FLASH_MS);
 };
 
-const saveField = async (key: ThemeKey) => {
+const saveField = async (key: ThemeSettingKey) => {
   const value = fields[key].trim();
   if (value === saved[key]) {
     fieldErrors[key] = "";
@@ -141,19 +134,19 @@ const saveField = async (key: ThemeKey) => {
   }
 };
 
-const scheduleSave = (key: ThemeKey) => {
+const scheduleSave = (key: ThemeSettingKey) => {
   clearTimeout(debounceTimers[key]);
   debounceTimers[key] = setTimeout(() => {
     void saveField(key);
   }, DEBOUNCE_MS);
 };
 
-const onInput = (key: ThemeKey) => {
+const onInput = (key: ThemeSettingKey) => {
   if (status[key] === "saved") status[key] = "idle";
   scheduleSave(key);
 };
 
-const onBlur = (key: ThemeKey) => {
+const onBlur = (key: ThemeSettingKey) => {
   clearTimeout(debounceTimers[key]);
   void saveField(key);
 };
@@ -165,7 +158,7 @@ const fetchSettings = async () => {
   try {
     const response = await $fetch<ThemeSettingsResponse>("/api/theme");
     if (response.success) {
-      for (const key of Object.keys(fields) as ThemeKey[]) {
+      for (const key of THEME_SETTING_KEYS) {
         const value = response.settings[key] ?? "";
         fields[key] = value;
         saved[key] = value;

--- a/components/ThemeSettings.vue
+++ b/components/ThemeSettings.vue
@@ -7,7 +7,7 @@ import {
   Home,
   Image,
   Loader2,
-  Palette,
+  Sparkles,
   XCircle,
 } from "lucide-vue-next";
 
@@ -66,7 +66,7 @@ const fieldDefs = computed(() => [
     label: t("themeSettings.logoUrl"),
     hint: t("themeSettings.logoUrlHint"),
     placeholder: t("themeSettings.logoUrlPlaceholder"),
-    icon: Palette,
+    icon: Sparkles,
   },
   {
     key: "background_image" as const,
@@ -258,11 +258,7 @@ onBeforeUnmount(clearTimers);
           {{ t("themeSettings.autosaveHint") }}
         </p>
 
-        <div
-          v-for="field in fieldDefs"
-          :key="field.key"
-          class="space-y-2"
-        >
+        <div v-for="field in fieldDefs" :key="field.key" class="space-y-2">
           <div class="flex items-center justify-between gap-3">
             <label
               :for="`theme-${field.key}`"

--- a/components/ThemeSettings.vue
+++ b/components/ThemeSettings.vue
@@ -1,0 +1,347 @@
+<script lang="ts" setup>
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
+import { $fetch } from "ofetch";
+import { navigateTo, refreshNuxtData, useI18n } from "#imports";
+import {
+  Check,
+  Home,
+  Image,
+  Loader2,
+  Palette,
+  XCircle,
+} from "lucide-vue-next";
+
+type ThemeKey = "logo_url" | "background_image";
+type FieldStatus = "idle" | "saving" | "saved" | "error";
+
+interface ThemeSettingsResponse {
+  success: boolean;
+  settings: Record<ThemeKey, string>;
+}
+
+interface ThemeSaveResponse {
+  success: boolean;
+  key: ThemeKey;
+  value: string;
+}
+
+const DEBOUNCE_MS = 700;
+const SAVED_FLASH_MS = 2000;
+
+const { t } = useI18n();
+
+const loading = ref(true);
+const loadError = ref("");
+
+const fields = reactive<Record<ThemeKey, string>>({
+  logo_url: "",
+  background_image: "",
+});
+
+const saved = reactive<Record<ThemeKey, string>>({
+  logo_url: "",
+  background_image: "",
+});
+
+const status = reactive<Record<ThemeKey, FieldStatus>>({
+  logo_url: "idle",
+  background_image: "idle",
+});
+
+const fieldErrors = reactive<Record<ThemeKey, string>>({
+  logo_url: "",
+  background_image: "",
+});
+
+const debounceTimers: Partial<Record<ThemeKey, ReturnType<typeof setTimeout>>> =
+  {};
+const savedFlashTimers: Partial<
+  Record<ThemeKey, ReturnType<typeof setTimeout>>
+> = {};
+const inFlight = new Map<ThemeKey, number>();
+
+const fieldDefs = computed(() => [
+  {
+    key: "logo_url" as const,
+    label: t("themeSettings.logoUrl"),
+    hint: t("themeSettings.logoUrlHint"),
+    placeholder: t("themeSettings.logoUrlPlaceholder"),
+    icon: Palette,
+  },
+  {
+    key: "background_image" as const,
+    label: t("themeSettings.backgroundImage"),
+    hint: t("themeSettings.backgroundImageHint"),
+    placeholder: t("themeSettings.backgroundImagePlaceholder"),
+    icon: Image,
+  },
+]);
+
+const clearTimers = () => {
+  for (const key of Object.keys(debounceTimers) as ThemeKey[]) {
+    clearTimeout(debounceTimers[key]);
+  }
+  for (const key of Object.keys(savedFlashTimers) as ThemeKey[]) {
+    clearTimeout(savedFlashTimers[key]);
+  }
+};
+
+const flashSaved = (key: ThemeKey) => {
+  status[key] = "saved";
+  clearTimeout(savedFlashTimers[key]);
+  savedFlashTimers[key] = setTimeout(() => {
+    if (status[key] === "saved") status[key] = "idle";
+  }, SAVED_FLASH_MS);
+};
+
+const saveField = async (key: ThemeKey) => {
+  const value = fields[key].trim();
+  if (value === saved[key]) {
+    fieldErrors[key] = "";
+    if (status[key] !== "saving") status[key] = "idle";
+    return;
+  }
+
+  const requestId = (inFlight.get(key) ?? 0) + 1;
+  inFlight.set(key, requestId);
+  status[key] = "saving";
+  fieldErrors[key] = "";
+
+  try {
+    const response = await $fetch<ThemeSaveResponse>("/api/theme", {
+      method: "POST",
+      body: { key, value },
+    });
+
+    if (inFlight.get(key) !== requestId) return;
+
+    if (response.success) {
+      saved[key] = response.value;
+      fields[key] = response.value;
+      flashSaved(key);
+      void refreshNuxtData("gc-theme-settings");
+    } else {
+      status[key] = "error";
+      fieldErrors[key] = t("themeSettings.failedToSave");
+    }
+  } catch (err: unknown) {
+    if (inFlight.get(key) !== requestId) return;
+    console.error(`Failed to save theme setting ${key}:`, err);
+    status[key] = "error";
+    const statusMessage =
+      err &&
+      typeof err === "object" &&
+      "data" in err &&
+      err.data &&
+      typeof err.data === "object" &&
+      "statusMessage" in err.data
+        ? String((err.data as { statusMessage?: string }).statusMessage)
+        : null;
+    fieldErrors[key] = statusMessage || t("themeSettings.failedToSave");
+  }
+};
+
+const scheduleSave = (key: ThemeKey) => {
+  clearTimeout(debounceTimers[key]);
+  debounceTimers[key] = setTimeout(() => {
+    void saveField(key);
+  }, DEBOUNCE_MS);
+};
+
+const onInput = (key: ThemeKey) => {
+  if (status[key] === "saved") status[key] = "idle";
+  scheduleSave(key);
+};
+
+const onBlur = (key: ThemeKey) => {
+  clearTimeout(debounceTimers[key]);
+  void saveField(key);
+};
+
+const fetchSettings = async () => {
+  loading.value = true;
+  loadError.value = "";
+
+  try {
+    const response = await $fetch<ThemeSettingsResponse>("/api/theme");
+    if (response.success) {
+      for (const key of Object.keys(fields) as ThemeKey[]) {
+        const value = response.settings[key] ?? "";
+        fields[key] = value;
+        saved[key] = value;
+        status[key] = "idle";
+        fieldErrors[key] = "";
+      }
+    } else {
+      loadError.value = t("themeSettings.failedToLoad");
+    }
+  } catch (err) {
+    console.error("Failed to load theme settings:", err);
+    loadError.value = t("themeSettings.failedToLoad");
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchSettings);
+onBeforeUnmount(clearTimers);
+</script>
+
+<template>
+  <div class="max-w-7xl mx-auto p-3 sm:p-6">
+    <!-- Desktop Header -->
+    <div class="mb-6 sm:mb-8 hidden sm:block">
+      <div class="flex justify-between items-start">
+        <div>
+          <h1
+            class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-dusk-100 mb-2"
+          >
+            {{ t("themeSettings.title") }}
+          </h1>
+          <p class="text-sm sm:text-base text-gray-600 dark:text-dusk-400">
+            {{ t("themeSettings.subtitle") }}
+          </p>
+        </div>
+        <div class="ml-4 flex items-center gap-3">
+          <button
+            @click="navigateTo('/')"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-dusk-200 bg-white dark:bg-dusk-800 border border-gray-300 dark:border-dusk-700 rounded-lg hover:bg-gray-50 dark:hover:bg-dusk-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-dusk-900 transition-colors cursor-pointer"
+          >
+            {{ t("themeSettings.returnToHomepage") }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mobile Header -->
+    <div class="mb-4 sm:hidden">
+      <div class="flex items-center justify-between">
+        <h1 class="text-xl font-bold text-gray-900 dark:text-dusk-100">
+          {{ t("themeSettings.title") }}
+        </h1>
+        <button
+          type="button"
+          @click="navigateTo('/')"
+          class="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-dusk-700 transition-colors"
+          :aria-label="t('themeSettings.returnToHomepage')"
+        >
+          <Home class="w-6 h-6 text-gray-700 dark:text-dusk-200" />
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="loadError"
+      class="mb-3 sm:mb-4 p-3 sm:p-4 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg"
+    >
+      <div class="flex">
+        <XCircle class="h-5 w-5 text-red-400 dark:text-red-300" />
+        <div class="ml-3">
+          <p class="text-sm text-red-800 dark:text-red-200">{{ loadError }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="bg-white dark:bg-dusk-800 rounded-lg shadow-sm border border-gray-200 dark:border-dusk-700 p-3 sm:p-6"
+    >
+      <div
+        v-if="loading"
+        class="flex items-center justify-center py-12 text-gray-500 dark:text-dusk-400"
+      >
+        <Loader2 class="h-6 w-6 animate-spin mr-2" />
+        <span class="text-sm">{{ t("themeSettings.loading") }}</span>
+      </div>
+
+      <div v-else class="space-y-6">
+        <p class="text-sm text-gray-500 dark:text-dusk-400">
+          {{ t("themeSettings.autosaveHint") }}
+        </p>
+
+        <div
+          v-for="field in fieldDefs"
+          :key="field.key"
+          class="space-y-2"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <label
+              :for="`theme-${field.key}`"
+              class="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-dusk-100"
+            >
+              <component
+                :is="field.icon"
+                class="h-4 w-4 text-violet-600 dark:text-violet-300"
+              />
+              {{ field.label }}
+            </label>
+
+            <div
+              class="flex items-center gap-1.5 text-xs min-h-[1.25rem]"
+              aria-live="polite"
+            >
+              <template v-if="status[field.key] === 'saving'">
+                <Loader2
+                  class="h-3.5 w-3.5 animate-spin text-violet-600 dark:text-violet-300"
+                />
+                <span class="text-gray-500 dark:text-dusk-400">{{
+                  t("themeSettings.saving")
+                }}</span>
+              </template>
+              <template v-else-if="status[field.key] === 'saved'">
+                <Check class="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+                <span class="text-green-600 dark:text-green-400">{{
+                  t("themeSettings.saved")
+                }}</span>
+              </template>
+              <template v-else-if="status[field.key] === 'error'">
+                <XCircle class="h-3.5 w-3.5 text-red-500 dark:text-red-400" />
+                <span class="text-red-600 dark:text-red-300">{{
+                  t("themeSettings.error")
+                }}</span>
+              </template>
+            </div>
+          </div>
+
+          <input
+            :id="`theme-${field.key}`"
+            v-model="fields[field.key]"
+            type="text"
+            inputmode="url"
+            autocomplete="off"
+            :placeholder="field.placeholder"
+            class="w-full px-3 py-2 text-sm sm:text-base bg-white dark:bg-dusk-700 text-gray-900 dark:text-dusk-100 placeholder-gray-400 dark:placeholder-dusk-500 border border-gray-300 dark:border-dusk-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+            @input="onInput(field.key)"
+            @blur="onBlur(field.key)"
+          />
+
+          <p class="text-xs text-gray-500 dark:text-dusk-400">
+            {{ field.hint }}
+          </p>
+          <p
+            v-if="fieldErrors[field.key]"
+            class="text-xs text-red-600 dark:text-red-300"
+          >
+            {{ fieldErrors[field.key] }}
+          </p>
+
+          <div
+            v-if="fields[field.key].trim()"
+            class="mt-2 rounded-lg border border-gray-200 dark:border-dusk-700 bg-gray-50 dark:bg-dusk-900/40 p-3"
+          >
+            <p
+              class="mb-2 text-xs font-medium text-gray-500 dark:text-dusk-400 uppercase tracking-wide"
+            >
+              {{ t("themeSettings.preview") }}
+            </p>
+            <img
+              :key="fields[field.key].trim()"
+              :src="fields[field.key].trim()"
+              :alt="field.label"
+              class="max-h-28 w-auto max-w-full object-contain rounded"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -9,9 +9,9 @@ import { translateRoleName } from "@/utils/roleTranslations";
 import { useAuthActions } from "@/composables/useAuth";
 import {
   BadgeCheck,
-  Layers,
   LogOut,
   Menu,
+  Palette,
   User as UserIcon,
   Users,
 } from "lucide-vue-next";
@@ -110,26 +110,11 @@ const { login, logout } = useAuthActions();
           </button>
         </div>
 
-        <!-- User info and controls -->
+        <!-- Auth controls when logged in -->
         <div
           v-if="isAuth0Configured && loggedIn"
           class="flex items-center space-x-3"
         >
-          <div
-            class="text-sm max-[1200px]:text-xs text-gray-700 dark:text-dusk-300"
-          >
-            {{ t("auth.welcome", { user: (user as User)?.auth0 || "User" }) }}
-            <span
-              v-if="(user as User)?.roles?.length"
-              class="text-xs max-[1200px]:text-[10px] text-gray-500 dark:text-dusk-400"
-            >
-              ({{
-                (user as User)?.roles
-                  ?.map((role) => translateRoleName(role.name, t))
-                  .join(", ")
-              }})
-            </span>
-          </div>
           <button
             @click="logout"
             class="text-gray-600 hover:text-gray-900 dark:text-dusk-400 dark:hover:text-dusk-100 transition-colors text-sm max-[1200px]:text-xs"
@@ -157,7 +142,26 @@ const { login, logout } = useAuthActions();
           </div>
         </div>
 
-        <!-- Theme Toggle -->
+        <!-- Theme Settings -->
+        <div
+          v-if="isAuth0Configured && loggedIn && isAdmin"
+          class="relative group"
+        >
+          <NuxtLink
+            to="/admin/theme"
+            class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-dusk-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-800"
+          >
+            <Palette class="w-5 h-5 text-gray-600 dark:text-dusk-300" />
+          </NuxtLink>
+          <!-- Tooltip -->
+          <div
+            class="absolute right-0 mt-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-dusk-600 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 whitespace-nowrap"
+          >
+            {{ t("auth.themeSettings") }}
+          </div>
+        </div>
+
+        <!-- Display (light / dark) Toggle -->
         <div class="relative group">
           <ThemeToggle theme="white" variant="icon" />
           <!-- Tooltip -->
@@ -258,7 +262,20 @@ const { login, logout } = useAuthActions();
         }}</span>
       </NuxtLink>
 
-      <!-- Theme Toggle -->
+      <!-- Theme Settings (if admin) -->
+      <NuxtLink
+        v-if="isAdmin"
+        to="/admin/theme"
+        @click="mobileMenuOpen = false"
+        class="flex items-center space-x-3 px-4 py-3 rounded-lg hover:bg-violet-50 dark:hover:bg-dusk-700 transition-colors mb-2"
+      >
+        <Palette class="w-5 h-5 text-gray-600 dark:text-dusk-300" />
+        <span class="text-sm text-gray-700 dark:text-dusk-200">{{
+          t("auth.themeSettings")
+        }}</span>
+      </NuxtLink>
+
+      <!-- Display (light / dark) Toggle -->
       <ThemeToggle variant="mobile" />
 
       <!-- Language Picker -->

--- a/composables/useThemeSettings.ts
+++ b/composables/useThemeSettings.ts
@@ -1,12 +1,10 @@
 import { computed } from "vue";
 import { useFetch } from "#imports";
+import type { ThemeSettingsMap } from "~/utils/themeSettings";
 
 interface ThemeSettingsResponse {
   success: boolean;
-  settings: {
-    logo_url: string;
-    background_image: string;
-  };
+  settings: ThemeSettingsMap;
 }
 
 const DEFAULT_BACKGROUND = "/background.jpg";

--- a/composables/useThemeSettings.ts
+++ b/composables/useThemeSettings.ts
@@ -1,0 +1,30 @@
+import { computed } from "vue";
+import { useFetch } from "#imports";
+
+interface ThemeSettingsResponse {
+  success: boolean;
+  settings: {
+    logo_url: string;
+    background_image: string;
+  };
+}
+
+const DEFAULT_BACKGROUND = "/background.jpg";
+
+export const useThemeSettings = () => {
+  const { data, pending, error, refresh } = useFetch<ThemeSettingsResponse>(
+    "/api/theme",
+    { key: "gc-theme-settings" },
+  );
+
+  const logoUrl = computed(
+    () => data.value?.settings?.logo_url?.trim() || "",
+  );
+
+  const backgroundImage = computed(() => {
+    const url = data.value?.settings?.background_image?.trim() || "";
+    return url || DEFAULT_BACKGROUND;
+  });
+
+  return { logoUrl, backgroundImage, pending, error, refresh };
+};

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -14,6 +14,7 @@
     "signIn": "Log in or register",
     "signOut": "Sign Out",
     "userManagement": "User Management",
+    "themeSettings": "Theme",
     "welcome": "Welcome, {user}",
     "coCreatedBy": "Co-created by",
     "andIndigenousPartners": "and Indigenous partners"
@@ -26,13 +27,32 @@
   "header": {
     "adminAccess": "Admin Access",
     "languagePicker": "Language Picker",
-    "themeToggle": "Theme"
+    "themeToggle": "Display"
   },
   "theme": {
     "light": "Light",
     "dark": "Dark",
     "switchToLight": "Switch to light mode",
     "switchToDark": "Switch to dark mode"
+  },
+  "themeSettings": {
+    "autosaveHint": "Changes save automatically a moment after you stop typing.",
+    "backgroundImage": "Background Image URL",
+    "backgroundImageHint": "Used on the login screen. Leave blank to use the default background.",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "Error",
+    "failedToLoad": "Failed to load theme settings",
+    "failedToSave": "Failed to save. Check the URL and try again.",
+    "loading": "Loading theme settings...",
+    "logoUrl": "Logo URL",
+    "logoUrlHint": "Shown on the homepage. Leave blank to hide the logo.",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "Preview",
+    "returnToHomepage": "Return to Homepage",
+    "saved": "Saved",
+    "saving": "Saving…",
+    "subtitle": "Customize your community branding",
+    "title": "Theme Settings"
   },
   "roles": {
     "admin": "Admin",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -14,6 +14,7 @@
     "signIn": "Inicie sesión o regístrese",
     "signOut": "Cerrar Sesión",
     "userManagement": "Gestión de Usuarios",
+    "themeSettings": "Tema",
     "welcome": "Bienvenido, {user}",
     "coCreatedBy": "Cocreado por",
     "andIndigenousPartners": "y socios indígenas"
@@ -49,13 +50,32 @@
   "header": {
     "adminAccess": "Acceso de Administrador",
     "languagePicker": "Selector de Idioma",
-    "themeToggle": "Tema"
+    "themeToggle": "Pantalla"
   },
   "theme": {
     "light": "Claro",
     "dark": "Oscuro",
     "switchToLight": "Cambiar a modo claro",
     "switchToDark": "Cambiar a modo oscuro"
+  },
+  "themeSettings": {
+    "autosaveHint": "Los cambios se guardan automáticamente un momento después de dejar de escribir.",
+    "backgroundImage": "URL de la imagen de fondo",
+    "backgroundImageHint": "Se usa en la pantalla de inicio de sesión. Déjalo en blanco para usar el fondo predeterminado.",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "Error",
+    "failedToLoad": "No se pudieron cargar los ajustes de tema",
+    "failedToSave": "No se pudo guardar. Revisa la URL e inténtalo de nuevo.",
+    "loading": "Cargando ajustes de tema...",
+    "logoUrl": "URL del logo",
+    "logoUrlHint": "Se muestra en la página de inicio. Déjalo en blanco para ocultar el logo.",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "Vista previa",
+    "returnToHomepage": "Volver al inicio",
+    "saved": "Guardado",
+    "saving": "Guardando…",
+    "subtitle": "Personaliza la marca de tu comunidad",
+    "title": "Ajustes de Tema"
   },
   "roles": {
     "admin": "Administrador",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -14,6 +14,7 @@
     "signIn": "Log in of meld u aan",
     "signOut": "Uitloggen",
     "userManagement": "Gebruikersbeheer",
+    "themeSettings": "Thema",
     "welcome": "Welkom, {user}",
     "coCreatedBy": "Mede ontwikkeld door",
     "andIndigenousPartners": "en inheemse partners"
@@ -49,13 +50,32 @@
   "header": {
     "adminAccess": "Beheerders Toegang",
     "languagePicker": "Taal Selector",
-    "themeToggle": "Thema"
+    "themeToggle": "Weergave"
   },
   "theme": {
     "light": "Licht",
     "dark": "Donker",
     "switchToLight": "Schakel naar lichte modus",
     "switchToDark": "Schakel naar donkere modus"
+  },
+  "themeSettings": {
+    "autosaveHint": "Wijzigingen worden automatisch opgeslagen kort nadat je stopt met typen.",
+    "backgroundImage": "URL van achtergrondafbeelding",
+    "backgroundImageHint": "Gebruikt op het inlogscherm. Laat leeg om de standaardachtergrond te gebruiken.",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "Fout",
+    "failedToLoad": "Thema-instellingen laden mislukt",
+    "failedToSave": "Opslaan mislukt. Controleer de URL en probeer opnieuw.",
+    "loading": "Thema-instellingen laden...",
+    "logoUrl": "Logo-URL",
+    "logoUrlHint": "Getoond op de homepage. Laat leeg om het logo te verbergen.",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "Voorbeeld",
+    "returnToHomepage": "Terug naar homepage",
+    "saved": "Opgeslagen",
+    "saving": "Opslaan…",
+    "subtitle": "Pas de branding van je community aan",
+    "title": "Thema-instellingen"
   },
   "roles": {
     "admin": "Beheerder",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -14,6 +14,7 @@
     "signIn": "Faça login ou inscreva-se",
     "signOut": "Sair",
     "userManagement": "Gerenciamento de Usuários",
+    "themeSettings": "Tema",
     "welcome": "Bem-vindo, {user}",
     "coCreatedBy": "Co-criado por",
     "andIndigenousPartners": "e parceiros indígenas"
@@ -49,13 +50,32 @@
   "header": {
     "adminAccess": "Acesso de Administrador",
     "languagePicker": "Seletor de Idioma",
-    "themeToggle": "Tema"
+    "themeToggle": "Exibição"
   },
   "theme": {
     "light": "Claro",
     "dark": "Escuro",
     "switchToLight": "Mudar para o modo claro",
     "switchToDark": "Mudar para o modo escuro"
+  },
+  "themeSettings": {
+    "autosaveHint": "As alterações são salvas automaticamente um momento após você parar de digitar.",
+    "backgroundImage": "URL da imagem de fundo",
+    "backgroundImageHint": "Usada na tela de login. Deixe em branco para usar o fundo padrão.",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "Erro",
+    "failedToLoad": "Falha ao carregar as configurações de tema",
+    "failedToSave": "Falha ao salvar. Verifique a URL e tente novamente.",
+    "loading": "Carregando configurações de tema...",
+    "logoUrl": "URL do logo",
+    "logoUrlHint": "Mostrado na página inicial. Deixe em branco para ocultar o logo.",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "Pré-visualização",
+    "returnToHomepage": "Voltar à página inicial",
+    "saved": "Salvo",
+    "saving": "Salvando…",
+    "subtitle": "Personalize a marca da sua comunidade",
+    "title": "Configurações de Tema"
   },
   "roles": {
     "admin": "Administrador",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -14,6 +14,7 @@
     "signIn": "Ingia au jisajili",
     "signOut": "Toka",
     "userManagement": "Usimamizi wa Watumiaji",
+    "themeSettings": "Mandhari",
     "welcome": "Karibu, {user}",
     "coCreatedBy": "Iliundwa kwa pamoja na",
     "andIndigenousPartners": "na washirika wa asili"
@@ -26,13 +27,32 @@
   "header": {
     "adminAccess": "Ufikiaji wa Msimamizi",
     "languagePicker": "Chagua lugha",
-    "themeToggle": "Mandhari"
+    "themeToggle": "Onyesho"
   },
   "theme": {
     "light": "Mwangaza",
     "dark": "Giza",
     "switchToLight": "Badilisha kuwa hali ya mwanga",
     "switchToDark": "Badilisha kuwa hali ya giza"
+  },
+  "themeSettings": {
+    "autosaveHint": "Mabadiliko huhifadhiwa kiotomatiki muda mfupi baada ya kuacha kuandika.",
+    "backgroundImage": "URL ya picha ya mandhari",
+    "backgroundImageHint": "Inatumika kwenye skrini ya kuingia. Acha tupu kutumia mandhari chaguo-msingi.",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "Hitilafu",
+    "failedToLoad": "Imeshindwa kupakia mipangilio ya mandhari",
+    "failedToSave": "Imeshindwa kuhifadhi. Angalia URL na ujaribu tena.",
+    "loading": "Inapakia mipangilio ya mandhari...",
+    "logoUrl": "URL ya nembo",
+    "logoUrlHint": "Inaonyeshwa kwenye ukurasa wa kuanza. Acha tupu kuficha nembo.",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "Hakiki",
+    "returnToHomepage": "Rudi kwenye ukurasa wa kuanza",
+    "saved": "Imehifadhiwa",
+    "saving": "Inahifadhi…",
+    "subtitle": "Binafsisha chapa ya jamii yako",
+    "title": "Mipangilio ya Mandhari"
   },
   "roles": {
     "admin": "Msimamizi",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -14,6 +14,7 @@
     "signIn": "เข้าสู่ระบบหรือสมัครสมาชิก",
     "signOut": "ออกจากระบบ",
     "userManagement": "การจัดการผู้ใช้",
+    "themeSettings": "ธีม",
     "welcome": "ยินดีต้อนรับ {user}",
     "coCreatedBy": "ร่วมสร้างโดย",
     "andIndigenousPartners": "และพันธมิตรชนพื้นเมือง"
@@ -49,13 +50,32 @@
   "header": {
     "adminAccess": "การเข้าถึงผู้ดูแล",
     "languagePicker": "เลือกภาษา",
-    "themeToggle": "ธีม"
+    "themeToggle": "การแสดงผล"
   },
   "theme": {
     "light": "สว่าง",
     "dark": "มืด",
     "switchToLight": "เปลี่ยนเป็นโหมดสว่าง",
     "switchToDark": "เปลี่ยนเป็นโหมดมืด"
+  },
+  "themeSettings": {
+    "autosaveHint": "การเปลี่ยนแปลงจะถูกบันทึกอัตโนมัติหลังคุณหยุดพิมพ์ไม่นาน",
+    "backgroundImage": "URL รูปพื้นหลัง",
+    "backgroundImageHint": "ใช้ในหน้าเข้าสู่ระบบ เว้นว่างเพื่อใช้พื้นหลังเริ่มต้น",
+    "backgroundImagePlaceholder": "https://example.com/background.jpg",
+    "error": "ข้อผิดพลาด",
+    "failedToLoad": "โหลดการตั้งค่าธีมไม่สำเร็จ",
+    "failedToSave": "บันทึกไม่สำเร็จ ตรวจสอบ URL แล้วลองอีกครั้ง",
+    "loading": "กำลังโหลดการตั้งค่าธีม...",
+    "logoUrl": "URL โลโก้",
+    "logoUrlHint": "แสดงในหน้าแรก เว้นว่างเพื่อซ่อนโลโก้",
+    "logoUrlPlaceholder": "https://example.com/logo.png",
+    "preview": "ตัวอย่าง",
+    "returnToHomepage": "กลับหน้าแรก",
+    "saved": "บันทึกแล้ว",
+    "saving": "กำลังบันทึก…",
+    "subtitle": "ปรับแต่งแบรนด์ของชุมชนคุณ",
+    "title": "การตั้งค่าธีม"
   },
   "roles": {
     "admin": "ผู้ดูแล",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,13 +60,11 @@ export default defineNuxtConfig({
       domain: "guardianconnector.net",
       baseUrl: "http://localhost:8080",
       auth0Enabled: true,
-      logoUrl: "",
       // Service availability flags
       supersetEnabled: false,
       windmillEnabled: false,
       explorerEnabled: false,
       filebrowserEnabled: false,
-      backgroundImage: "",
     },
   },
 });

--- a/pages/admin/theme.vue
+++ b/pages/admin/theme.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { useUserSession, navigateTo, createError, useHead } from "#imports";
+import ThemeSettings from "~/components/ThemeSettings.vue";
+// i18n is auto-imported by @nuxtjs/i18n
+
+const { t } = useI18n();
+
+interface UserWithRoles {
+  roles?: Array<{ name: string; id: string; description: string }>;
+}
+
+const { loggedIn, user } = useUserSession();
+
+if (!loggedIn.value) {
+  await navigateTo("/login");
+}
+
+const hasAdminRole = (user.value as UserWithRoles)?.roles?.some(
+  (role) => role.name === "Admin",
+);
+
+if (!hasAdminRole) {
+  throw createError({
+    statusCode: 403,
+    statusMessage: "Access denied. Admin privileges required.",
+  });
+}
+
+useHead({
+  title: t("themeSettings.title") + " - Admin",
+  meta: [{ name: "description", content: t("themeSettings.subtitle") }],
+});
+</script>
+
+<template>
+  <ThemeSettings />
+</template>

--- a/server/api/theme.get.ts
+++ b/server/api/theme.get.ts
@@ -1,0 +1,18 @@
+import { getThemeSettings } from "~/server/utils/themeSettings";
+
+/** Public: logo and background are site branding, not secrets. */
+export default defineEventHandler(async () => {
+  try {
+    const settings = await getThemeSettings();
+    return { success: true, settings };
+  } catch (error) {
+    console.error("Error fetching theme settings:", error);
+    if (error && typeof error === "object" && "statusCode" in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal server error",
+    });
+  }
+});

--- a/server/api/theme.post.ts
+++ b/server/api/theme.post.ts
@@ -1,0 +1,51 @@
+import { configDb, schema } from "~/server/database/dbConnection";
+import { requireAdminSession } from "~/server/utils/auth";
+import {
+  isThemeSettingKey,
+  isValidThemeUrl,
+} from "~/server/utils/themeSettings";
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminSession(event);
+
+    const body = await readBody<{ key?: string; value?: string }>(event);
+    const key = body?.key?.trim() ?? "";
+    const value = typeof body?.value === "string" ? body.value.trim() : "";
+
+    if (!isThemeSettingKey(key)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "Invalid theme setting key",
+      });
+    }
+
+    if (!isValidThemeUrl(value)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "Invalid URL. Use http(s) or a path starting with /.",
+      });
+    }
+
+    const updatedAt = new Date();
+
+    await configDb
+      .insert(schema.gcSettings)
+      .values({ key, value, updatedAt })
+      .onConflictDoUpdate({
+        target: schema.gcSettings.key,
+        set: { value, updatedAt },
+      });
+
+    return { success: true, key, value, updatedAt: updatedAt.toISOString() };
+  } catch (error) {
+    console.error("Error saving theme setting:", error);
+    if (error && typeof error === "object" && "statusCode" in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal server error",
+    });
+  }
+});

--- a/server/utils/themeSettings.ts
+++ b/server/utils/themeSettings.ts
@@ -1,35 +1,20 @@
 import { inArray } from "drizzle-orm";
 import { configDb, schema } from "~/server/database/dbConnection";
+import {
+  THEME_SETTING_KEYS,
+  emptyThemeSettings,
+  isThemeSettingKey,
+  type ThemeSettingsMap,
+} from "~/utils/themeSettings";
 
-export const THEME_SETTING_KEYS = [
-  "logo_url",
-  "background_image",
-] as const;
-
-export type ThemeSettingKey = (typeof THEME_SETTING_KEYS)[number];
-
-export type ThemeSettingsMap = Record<ThemeSettingKey, string>;
-
-export const isThemeSettingKey = (key: string): key is ThemeSettingKey =>
-  (THEME_SETTING_KEYS as readonly string[]).includes(key);
-
-/** Empty clears the setting; absolute http(s) URLs and root-relative paths are allowed. */
-export const isValidThemeUrl = (value: string): boolean => {
-  const trimmed = value.trim();
-  if (!trimmed) return true;
-  if (trimmed.startsWith("/")) return true;
-  try {
-    const url = new URL(trimmed);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-};
-
-export const emptyThemeSettings = (): ThemeSettingsMap =>
-  Object.fromEntries(
-    THEME_SETTING_KEYS.map((key) => [key, ""]),
-  ) as ThemeSettingsMap;
+export {
+  THEME_SETTING_KEYS,
+  emptyThemeSettings,
+  isThemeSettingKey,
+  isValidThemeUrl,
+  type ThemeSettingKey,
+  type ThemeSettingsMap,
+} from "~/utils/themeSettings";
 
 export const getThemeSettings = async (): Promise<ThemeSettingsMap> => {
   const settings = emptyThemeSettings();

--- a/server/utils/themeSettings.ts
+++ b/server/utils/themeSettings.ts
@@ -1,0 +1,48 @@
+import { inArray } from "drizzle-orm";
+import { configDb, schema } from "~/server/database/dbConnection";
+
+export const THEME_SETTING_KEYS = [
+  "logo_url",
+  "background_image",
+] as const;
+
+export type ThemeSettingKey = (typeof THEME_SETTING_KEYS)[number];
+
+export type ThemeSettingsMap = Record<ThemeSettingKey, string>;
+
+export const isThemeSettingKey = (key: string): key is ThemeSettingKey =>
+  (THEME_SETTING_KEYS as readonly string[]).includes(key);
+
+/** Empty clears the setting; absolute http(s) URLs and root-relative paths are allowed. */
+export const isValidThemeUrl = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (trimmed.startsWith("/")) return true;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const emptyThemeSettings = (): ThemeSettingsMap =>
+  Object.fromEntries(
+    THEME_SETTING_KEYS.map((key) => [key, ""]),
+  ) as ThemeSettingsMap;
+
+export const getThemeSettings = async (): Promise<ThemeSettingsMap> => {
+  const settings = emptyThemeSettings();
+  const rows = await configDb
+    .select()
+    .from(schema.gcSettings)
+    .where(inArray(schema.gcSettings.key, [...THEME_SETTING_KEYS]));
+
+  for (const row of rows) {
+    if (isThemeSettingKey(row.key)) {
+      settings[row.key] = row.value;
+    }
+  }
+
+  return settings;
+};

--- a/utils/themeSettings.ts
+++ b/utils/themeSettings.ts
@@ -1,0 +1,29 @@
+export const THEME_SETTING_KEYS = [
+  "logo_url",
+  "background_image",
+] as const;
+
+export type ThemeSettingKey = (typeof THEME_SETTING_KEYS)[number];
+
+export type ThemeSettingsMap = Record<ThemeSettingKey, string>;
+
+export const isThemeSettingKey = (key: string): key is ThemeSettingKey =>
+  (THEME_SETTING_KEYS as readonly string[]).includes(key);
+
+/** Empty clears the setting; absolute http(s) URLs and root-relative paths are allowed. */
+export const isValidThemeUrl = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (trimmed.startsWith("/")) return true;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const emptyThemeSettings = (): ThemeSettingsMap =>
+  Object.fromEntries(
+    THEME_SETTING_KEYS.map((key) => [key, ""]),
+  ) as ThemeSettingsMap;


### PR DESCRIPTION
## Goal

Taking advantage of https://github.com/ConservationMetrics/gc-landing-page/pull/84 creating the `gc_settings` table, this PR closes https://github.com/ConservationMetrics/gc-landing-page/issues/79 by adding API endpoints and front end to have the client set and retrieve logo and background image URLs.

## Screenshots

<img width="1263" height="864" alt="image" src="https://github.com/user-attachments/assets/c399ae65-87c3-40bd-83ca-6b581c88bcac" />

## What I changed and why

- e44698ec94b1d0600f90de728e450635aa57e0fe adds GET and POST API routes
- 21dd49fd6258964abaa7d8247c6fbcf42ddffecb adds the page and component
- 98a26d3ddb92ddaff95713b0adef2ea880d4725f localization
- cc5ea363ca6ecd0824428f761ce799753aab969f adds a button to the header. I decided to remove the "Welcome {user}" because it took up a lot of real estate.
- 389f91e15b9da7a4ff222441364e4cc31c64a01a has the client using the new k/v pairs for Logo URL and Background Image from `gc_settings`, and removing the env vars where found.

## How I convinced myself this is right

Trying it out in runtime.

## What I'm not doing here

The line count is +700, but I didn't break this up into two PRs (i.e. one API-only and the other frontend) because I felt the code changes were so straightforward. But I can do this if desired.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5 did most of the work based on a very detailed prompt I gave.