### PR TITLE
Drizzle failing to create gc_settings table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ WORKDIR /app
 # Copy built application from builder stage
 COPY --from=builder /app/.output ./.output
 
+# Copy SQL migrations (migrate.ts Nitro plugin reads these from disk at runtime)
+COPY --from=builder /app/server/database/migrations ./server/database/migrations
+
 # Copy package files for runtime dependencies
 COPY package*.json ./
 

--- a/composables/useThemeSettings.ts
+++ b/composables/useThemeSettings.ts
@@ -15,9 +15,7 @@ export const useThemeSettings = () => {
     { key: "gc-theme-settings" },
   );
 
-  const logoUrl = computed(
-    () => data.value?.settings?.logo_url?.trim() || "",
-  );
+  const logoUrl = computed(() => data.value?.settings?.logo_url?.trim() || "");
 
   const backgroundImage = computed(() => {
     const url = data.value?.settings?.background_image?.trim() || "";

--- a/server/plugins/migrate.ts
+++ b/server/plugins/migrate.ts
@@ -7,5 +7,10 @@ import { configDb } from "../database/dbConnection";
 export default defineNitroPlugin(async () => {
   await migrate(configDb, {
     migrationsFolder: resolve("./server/database/migrations"),
+    // gc-exp shares this database and already writes to the default
+    // drizzle.__drizzle_migrations table. Sharing that table makes drizzle
+    // skip our migrations (it only compares timestamps), so keep separate
+    // bookkeeping for this app.
+    migrationsTable: "__drizzle_migrations_landing_page",
   });
 });

--- a/utils/themeSettings.ts
+++ b/utils/themeSettings.ts
@@ -1,7 +1,4 @@
-export const THEME_SETTING_KEYS = [
-  "logo_url",
-  "background_image",
-] as const;
+export const THEME_SETTING_KEYS = ["logo_url", "background_image"] as const;
 
 export type ThemeSettingKey = (typeof THEME_SETTING_KEYS)[number];
 


### PR DESCRIPTION
## Goal

Fix production startup failure on CapRover VMs: Drizzle migrations never run, so `gc_settings` (and all other tables) don't exist and every `/api/theme` request fails with `relation "gc_settings" does not exist` (42P01). Closes #92 

## Screenshots


## What I changed and why

Added one line to the production stage of the `Dockerfile`:

```dockerfile
COPY --from=builder /app/server/database/migrations ./server/database/migrations
```

## How I Convinced Myself This Is Right 

Built the image locally and confirmed