### PR TITLE
For saving theme settings, switch from auto-save to explicit save button

### DIFF
--- a/components/ThemeSettings.vue
+++ b/components/ThemeSettings.vue
@@ -17,7 +17,7 @@ import {
   type ThemeSettingsMap,
 } from "~/utils/themeSettings";
 
-type FieldStatus = "idle" | "saving" | "saved" | "error";
+type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 interface ThemeSettingsResponse {
   success: boolean;
@@ -30,30 +30,20 @@ interface ThemeSaveResponse {
   value: string;
 }
 
-const DEBOUNCE_MS = 700;
 const SAVED_FLASH_MS = 2000;
 
 const { t } = useI18n();
 
 const loading = ref(true);
 const loadError = ref("");
+const saveStatus = ref<SaveStatus>("idle");
+const saveError = ref("");
 
 const fields = reactive(emptyThemeSettings());
 const saved = reactive(emptyThemeSettings());
-const status = reactive(
-  Object.fromEntries(
-    THEME_SETTING_KEYS.map((key) => [key, "idle" as FieldStatus]),
-  ) as Record<ThemeSettingKey, FieldStatus>,
-);
 const fieldErrors = reactive(emptyThemeSettings());
 
-const debounceTimers: Partial<
-  Record<ThemeSettingKey, ReturnType<typeof setTimeout>>
-> = {};
-const savedFlashTimers: Partial<
-  Record<ThemeSettingKey, ReturnType<typeof setTimeout>>
-> = {};
-const inFlight = new Map<ThemeSettingKey, number>();
+let savedFlashTimer: ReturnType<typeof setTimeout> | undefined;
 
 const fieldDefs = computed(() => [
   {
@@ -72,32 +62,39 @@ const fieldDefs = computed(() => [
   },
 ]);
 
-const clearTimers = () => {
-  for (const key of THEME_SETTING_KEYS) {
-    clearTimeout(debounceTimers[key]);
-    clearTimeout(savedFlashTimers[key]);
-  }
+const isDirty = computed(() =>
+  THEME_SETTING_KEYS.some((key) => fields[key].trim() !== saved[key]),
+);
+
+const flashSaved = () => {
+  saveStatus.value = "saved";
+  clearTimeout(savedFlashTimer);
+  savedFlashTimer = setTimeout(() => {
+    if (saveStatus.value === "saved") saveStatus.value = "idle";
+  }, SAVED_FLASH_MS);
 };
 
-const flashSaved = (key: ThemeSettingKey) => {
-  status[key] = "saved";
-  clearTimeout(savedFlashTimers[key]);
-  savedFlashTimers[key] = setTimeout(() => {
-    if (status[key] === "saved") status[key] = "idle";
-  }, SAVED_FLASH_MS);
+const getErrorMessage = (err: unknown) => {
+  if (
+    err &&
+    typeof err === "object" &&
+    "data" in err &&
+    err.data &&
+    typeof err.data === "object" &&
+    "statusMessage" in err.data
+  ) {
+    return String((err.data as { statusMessage?: string }).statusMessage);
+  }
+  return t("themeSettings.failedToSave");
 };
 
 const saveField = async (key: ThemeSettingKey) => {
   const value = fields[key].trim();
   if (value === saved[key]) {
     fieldErrors[key] = "";
-    if (status[key] !== "saving") status[key] = "idle";
-    return;
+    return true;
   }
 
-  const requestId = (inFlight.get(key) ?? 0) + 1;
-  inFlight.set(key, requestId);
-  status[key] = "saving";
   fieldErrors[key] = "";
 
   try {
@@ -106,49 +103,39 @@ const saveField = async (key: ThemeSettingKey) => {
       body: { key, value },
     });
 
-    if (inFlight.get(key) !== requestId) return;
-
-    if (response.success) {
-      saved[key] = response.value;
-      fields[key] = response.value;
-      flashSaved(key);
-      void refreshNuxtData("gc-theme-settings");
-    } else {
-      status[key] = "error";
+    if (!response.success) {
       fieldErrors[key] = t("themeSettings.failedToSave");
+      return false;
     }
+
+    saved[key] = response.value;
+    fields[key] = response.value;
+    return true;
   } catch (err: unknown) {
-    if (inFlight.get(key) !== requestId) return;
     console.error(`Failed to save theme setting ${key}:`, err);
-    status[key] = "error";
-    const statusMessage =
-      err &&
-      typeof err === "object" &&
-      "data" in err &&
-      err.data &&
-      typeof err.data === "object" &&
-      "statusMessage" in err.data
-        ? String((err.data as { statusMessage?: string }).statusMessage)
-        : null;
-    fieldErrors[key] = statusMessage || t("themeSettings.failedToSave");
+    fieldErrors[key] = getErrorMessage(err);
+    return false;
   }
 };
 
-const scheduleSave = (key: ThemeSettingKey) => {
-  clearTimeout(debounceTimers[key]);
-  debounceTimers[key] = setTimeout(() => {
-    void saveField(key);
-  }, DEBOUNCE_MS);
-};
+const saveSettings = async () => {
+  if (!isDirty.value || saveStatus.value === "saving") return;
 
-const onInput = (key: ThemeSettingKey) => {
-  if (status[key] === "saved") status[key] = "idle";
-  scheduleSave(key);
-};
+  saveStatus.value = "saving";
+  saveError.value = "";
 
-const onBlur = (key: ThemeSettingKey) => {
-  clearTimeout(debounceTimers[key]);
-  void saveField(key);
+  const dirtyKeys = THEME_SETTING_KEYS.filter(
+    (key) => fields[key].trim() !== saved[key],
+  );
+  const results = await Promise.all(dirtyKeys.map(saveField));
+
+  if (results.every(Boolean)) {
+    flashSaved();
+    void refreshNuxtData("gc-theme-settings");
+  } else {
+    saveStatus.value = "error";
+    saveError.value = t("themeSettings.failedToSave");
+  }
 };
 
 const fetchSettings = async () => {
@@ -162,9 +149,10 @@ const fetchSettings = async () => {
         const value = response.settings[key] ?? "";
         fields[key] = value;
         saved[key] = value;
-        status[key] = "idle";
         fieldErrors[key] = "";
       }
+      saveStatus.value = "idle";
+      saveError.value = "";
     } else {
       loadError.value = t("themeSettings.failedToLoad");
     }
@@ -177,7 +165,7 @@ const fetchSettings = async () => {
 };
 
 onMounted(fetchSettings);
-onBeforeUnmount(clearTimers);
+onBeforeUnmount(() => clearTimeout(savedFlashTimer));
 </script>
 
 <template>
@@ -248,48 +236,20 @@ onBeforeUnmount(clearTimers);
 
       <div v-else class="space-y-6">
         <p class="text-sm text-gray-500 dark:text-dusk-400">
-          {{ t("themeSettings.autosaveHint") }}
+          {{ t("themeSettings.saveHint") }}
         </p>
 
         <div v-for="field in fieldDefs" :key="field.key" class="space-y-2">
-          <div class="flex items-center justify-between gap-3">
-            <label
-              :for="`theme-${field.key}`"
-              class="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-dusk-100"
-            >
-              <component
-                :is="field.icon"
-                class="h-4 w-4 text-violet-600 dark:text-violet-300"
-              />
-              {{ field.label }}
-            </label>
-
-            <div
-              class="flex items-center gap-1.5 text-xs min-h-[1.25rem]"
-              aria-live="polite"
-            >
-              <template v-if="status[field.key] === 'saving'">
-                <Loader2
-                  class="h-3.5 w-3.5 animate-spin text-violet-600 dark:text-violet-300"
-                />
-                <span class="text-gray-500 dark:text-dusk-400">{{
-                  t("themeSettings.saving")
-                }}</span>
-              </template>
-              <template v-else-if="status[field.key] === 'saved'">
-                <Check class="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
-                <span class="text-green-600 dark:text-green-400">{{
-                  t("themeSettings.saved")
-                }}</span>
-              </template>
-              <template v-else-if="status[field.key] === 'error'">
-                <XCircle class="h-3.5 w-3.5 text-red-500 dark:text-red-400" />
-                <span class="text-red-600 dark:text-red-300">{{
-                  t("themeSettings.error")
-                }}</span>
-              </template>
-            </div>
-          </div>
+          <label
+            :for="`theme-${field.key}`"
+            class="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-dusk-100"
+          >
+            <component
+              :is="field.icon"
+              class="h-4 w-4 text-violet-600 dark:text-violet-300"
+            />
+            {{ field.label }}
+          </label>
 
           <input
             :id="`theme-${field.key}`"
@@ -299,8 +259,6 @@ onBeforeUnmount(clearTimers);
             autocomplete="off"
             :placeholder="field.placeholder"
             class="w-full px-3 py-2 text-sm sm:text-base bg-white dark:bg-dusk-700 text-gray-900 dark:text-dusk-100 placeholder-gray-400 dark:placeholder-dusk-500 border border-gray-300 dark:border-dusk-700 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-transparent"
-            @input="onInput(field.key)"
-            @blur="onBlur(field.key)"
           />
 
           <p class="text-xs text-gray-500 dark:text-dusk-400">
@@ -328,6 +286,44 @@ onBeforeUnmount(clearTimers);
               :alt="field.label"
               class="max-h-28 w-auto max-w-full object-contain rounded"
             />
+          </div>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-3 pt-2">
+          <button
+            type="button"
+            :disabled="!isDirty || saveStatus === 'saving'"
+            class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-violet-600 rounded-lg hover:bg-violet-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-dusk-800 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="saveSettings"
+          >
+            <Loader2
+              v-if="saveStatus === 'saving'"
+              class="h-4 w-4 animate-spin mr-2"
+            />
+            {{ t("themeSettings.save") }}
+          </button>
+
+          <div
+            class="flex items-center gap-1.5 text-xs min-h-[1.25rem]"
+            aria-live="polite"
+          >
+            <template v-if="saveStatus === 'saving'">
+              <span class="text-gray-500 dark:text-dusk-400">{{
+                t("themeSettings.saving")
+              }}</span>
+            </template>
+            <template v-else-if="saveStatus === 'saved'">
+              <Check class="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+              <span class="text-green-600 dark:text-green-400">{{
+                t("themeSettings.saved")
+              }}</span>
+            </template>
+            <template v-else-if="saveStatus === 'error'">
+              <XCircle class="h-3.5 w-3.5 text-red-500 dark:text-red-400" />
+              <span class="text-red-600 dark:text-red-300">{{
+                saveError || t("themeSettings.error")
+              }}</span>
+            </template>
           </div>
         </div>
       </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -36,7 +36,6 @@
     "switchToDark": "Switch to dark mode"
   },
   "themeSettings": {
-    "autosaveHint": "Changes save automatically a moment after you stop typing.",
     "backgroundImage": "Background Image URL",
     "backgroundImageHint": "Used on the login screen. Leave blank to use the default background.",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -49,6 +48,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "Preview",
     "returnToHomepage": "Return to Homepage",
+    "save": "Save",
+    "saveHint": "Preview updates as you type. Click Save to apply your changes.",
     "saved": "Saved",
     "saving": "Saving…",
     "subtitle": "Customize your community branding",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -59,7 +59,6 @@
     "switchToDark": "Cambiar a modo oscuro"
   },
   "themeSettings": {
-    "autosaveHint": "Los cambios se guardan automáticamente un momento después de dejar de escribir.",
     "backgroundImage": "URL de la imagen de fondo",
     "backgroundImageHint": "Se usa en la pantalla de inicio de sesión. Déjalo en blanco para usar el fondo predeterminado.",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -72,6 +71,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "Vista previa",
     "returnToHomepage": "Volver al inicio",
+    "save": "Guardar",
+    "saveHint": "La vista previa se actualiza al escribir. Haz clic en Guardar para aplicar los cambios.",
     "saved": "Guardado",
     "saving": "Guardando…",
     "subtitle": "Personaliza la marca de tu comunidad",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -59,7 +59,6 @@
     "switchToDark": "Schakel naar donkere modus"
   },
   "themeSettings": {
-    "autosaveHint": "Wijzigingen worden automatisch opgeslagen kort nadat je stopt met typen.",
     "backgroundImage": "URL van achtergrondafbeelding",
     "backgroundImageHint": "Gebruikt op het inlogscherm. Laat leeg om de standaardachtergrond te gebruiken.",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -72,6 +71,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "Voorbeeld",
     "returnToHomepage": "Terug naar homepage",
+    "save": "Opslaan",
+    "saveHint": "Het voorbeeld werkt bij tijdens het typen. Klik op Opslaan om je wijzigingen toe te passen.",
     "saved": "Opgeslagen",
     "saving": "Opslaan…",
     "subtitle": "Pas de branding van je community aan",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -59,7 +59,6 @@
     "switchToDark": "Mudar para o modo escuro"
   },
   "themeSettings": {
-    "autosaveHint": "As alterações são salvas automaticamente um momento após você parar de digitar.",
     "backgroundImage": "URL da imagem de fundo",
     "backgroundImageHint": "Usada na tela de login. Deixe em branco para usar o fundo padrão.",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -72,6 +71,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "Pré-visualização",
     "returnToHomepage": "Voltar à página inicial",
+    "save": "Salvar",
+    "saveHint": "A pré-visualização atualiza enquanto você digita. Clique em Salvar para aplicar as alterações.",
     "saved": "Salvo",
     "saving": "Salvando…",
     "subtitle": "Personalize a marca da sua comunidade",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -36,7 +36,6 @@
     "switchToDark": "Badilisha kuwa hali ya giza"
   },
   "themeSettings": {
-    "autosaveHint": "Mabadiliko huhifadhiwa kiotomatiki muda mfupi baada ya kuacha kuandika.",
     "backgroundImage": "URL ya picha ya mandhari",
     "backgroundImageHint": "Inatumika kwenye skrini ya kuingia. Acha tupu kutumia mandhari chaguo-msingi.",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -49,6 +48,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "Hakiki",
     "returnToHomepage": "Rudi kwenye ukurasa wa kuanza",
+    "save": "Hifadhi",
+    "saveHint": "Hakiki inasasishwa unapoandika. Bofya Hifadhi kutekeleza mabadiliko yako.",
     "saved": "Imehifadhiwa",
     "saving": "Inahifadhi…",
     "subtitle": "Binafsisha chapa ya jamii yako",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -59,7 +59,6 @@
     "switchToDark": "เปลี่ยนเป็นโหมดมืด"
   },
   "themeSettings": {
-    "autosaveHint": "การเปลี่ยนแปลงจะถูกบันทึกอัตโนมัติหลังคุณหยุดพิมพ์ไม่นาน",
     "backgroundImage": "URL รูปพื้นหลัง",
     "backgroundImageHint": "ใช้ในหน้าเข้าสู่ระบบ เว้นว่างเพื่อใช้พื้นหลังเริ่มต้น",
     "backgroundImagePlaceholder": "https://example.com/background.jpg",
@@ -72,6 +71,8 @@
     "logoUrlPlaceholder": "https://example.com/logo.png",
     "preview": "ตัวอย่าง",
     "returnToHomepage": "กลับหน้าแรก",
+    "save": "บันทึก",
+    "saveHint": "ตัวอย่างจะอัปเดตขณะพิมพ์ กดบันทึกเพื่อใช้การเปลี่ยนแปลง",
     "saved": "บันทึกแล้ว",
     "saving": "กำลังบันทึก…",
     "subtitle": "ปรับแต่งแบรนด์ของชุมชนคุณ",


### PR DESCRIPTION
## Goal

Closes #94. I agree with @nicopace that we should use a more explicit, user-triggered action, insofar as that is what we do across the rest of Guardian Connector.

## Screenshots

<img width="592" height="847" alt="image" src="https://github.com/user-attachments/assets/257dc90e-8573-4839-80fc-7b837e6584eb" />

## What I changed and why

- Replaced debounce/autosave-on-type with an explicit Save button.
- Kept live preview on input so admins can still check URLs before committing.
- Updated locale copy to describe preview-as-you-type + Save instead of autosave.

## How I convinced myself this is right

Trying in runtime.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5 did translations and all of the template.