### PR TITLE
Add CustomApp types, the gc_custom_apps Drizzle schema, and its migration

### DIFF
--- a/server/database/migrations/0001_reflective_deadpool.sql
+++ b/server/database/migrations/0001_reflective_deadpool.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "gc_custom_apps" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"icon_url" text NOT NULL,
+	"tags" text[] DEFAULT '{}' NOT NULL,
+	"subdomain" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"sort_order" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "gc_custom_apps_subdomain_unique" UNIQUE("subdomain")
+);
+--> statement-breakpoint
+CREATE INDEX "gc_custom_apps_enabled_sort_order_idx" ON "gc_custom_apps" USING btree ("enabled","sort_order");

--- a/server/database/migrations/meta/0001_snapshot.json
+++ b/server/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,158 @@
+{
+  "id": "35e87e99-55fe-4fb1-b40b-aa9a2c60c524",
+  "prevId": "88292026-15ed-408c-a0ff-e19a7dd64cf4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.gc_custom_apps": {
+      "name": "gc_custom_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gc_custom_apps_enabled_sort_order_idx": {
+          "name": "gc_custom_apps_enabled_sort_order_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gc_custom_apps_subdomain_unique": {
+          "name": "gc_custom_apps_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gc_settings": {
+      "name": "gc_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781775197497,
       "tag": "0000_foamy_mentor",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1786467230401,
+      "tag": "0001_reflective_deadpool",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,7 +1,40 @@
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
 
 export const gcSettings = pgTable("gc_settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
 });
+
+export const gcCustomApps = pgTable(
+  "gc_custom_apps",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    iconUrl: text("icon_url").notNull(),
+    tags: text("tags").array().notNull().default([]),
+    subdomain: text("subdomain").notNull().unique(),
+    enabled: boolean("enabled").notNull().default(true),
+    sortOrder: integer("sort_order").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("gc_custom_apps_enabled_sort_order_idx").on(
+      table.enabled,
+      table.sortOrder,
+    ),
+  ],
+);

--- a/server/utils/customApps.ts
+++ b/server/utils/customApps.ts
@@ -1,0 +1,100 @@
+import { asc, eq } from "drizzle-orm";
+import { configDb, schema } from "~/server/database/dbConnection";
+import {
+  emptyCustomApps,
+  type CustomApp,
+  type CustomAppsValidationResult,
+  validateCustomAppsPayload,
+} from "~/utils/customApps";
+
+export {
+  CUSTOM_APP_MIN_ROLE,
+  CUSTOM_APPS_MAX,
+  buildCustomAppUrl,
+  emptyCustomApps,
+  isValidCustomAppIconUrl,
+  isValidCustomAppId,
+  isValidCustomAppSubdomain,
+  slugifyCustomAppId,
+  validateCustomAppsPayload,
+  type CustomApp,
+  type CustomAppInput,
+  type CustomAppValidationError,
+  type CustomAppsValidationResult,
+} from "~/utils/customApps";
+
+type CustomAppRow = typeof schema.gcCustomApps.$inferSelect;
+
+export const mapCustomAppRow = (row: CustomAppRow): CustomApp => ({
+  id: row.id,
+  name: row.name,
+  description: row.description,
+  iconUrl: row.iconUrl,
+  tags: row.tags ?? [],
+  subdomain: row.subdomain,
+  enabled: row.enabled,
+  sortOrder: row.sortOrder,
+});
+
+export const listCustomApps = async (
+  options: { includeDisabled?: boolean } = {},
+): Promise<CustomApp[]> => {
+  const { includeDisabled = false } = options;
+
+  const base = configDb.select().from(schema.gcCustomApps);
+  const filtered = includeDisabled
+    ? base
+    : base.where(eq(schema.gcCustomApps.enabled, true));
+  const rows = await filtered.orderBy(
+    asc(schema.gcCustomApps.sortOrder),
+    asc(schema.gcCustomApps.id),
+  );
+
+  if (rows.length === 0) return emptyCustomApps();
+  return rows.map(mapCustomAppRow);
+};
+
+/**
+ * Replaces the full custom-apps list in a transaction.
+ * Caller must pass a payload already validated via validateCustomAppsPayload.
+ */
+export const replaceCustomApps = async (
+  apps: CustomApp[],
+): Promise<CustomApp[]> => {
+  const now = new Date();
+
+  await configDb.transaction(async (tx) => {
+    await tx.delete(schema.gcCustomApps);
+
+    if (apps.length === 0) return;
+
+    await tx.insert(schema.gcCustomApps).values(
+      apps.map((app, index) => ({
+        id: app.id,
+        name: app.name,
+        description: app.description,
+        iconUrl: app.iconUrl,
+        tags: app.tags,
+        subdomain: app.subdomain,
+        enabled: app.enabled,
+        sortOrder: index,
+        createdAt: now,
+        updatedAt: now,
+      })),
+    );
+  });
+
+  return listCustomApps({ includeDisabled: true });
+};
+
+export const parseAndValidateCustomAppsBody = (
+  body: unknown,
+): CustomAppsValidationResult => {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      errors: [{ index: -1, message: "body must be an object" }],
+    };
+  }
+  return validateCustomAppsPayload((body as { apps?: unknown }).apps);
+};

--- a/server/utils/customApps.ts
+++ b/server/utils/customApps.ts
@@ -63,28 +63,34 @@ export const replaceCustomApps = async (
 ): Promise<CustomApp[]> => {
   const now = new Date();
 
-  await configDb.transaction(async (tx) => {
+  return configDb.transaction(async (tx) => {
     await tx.delete(schema.gcCustomApps);
 
-    if (apps.length === 0) return;
+    if (apps.length === 0) return emptyCustomApps();
 
-    await tx.insert(schema.gcCustomApps).values(
-      apps.map((app, index) => ({
-        id: app.id,
-        name: app.name,
-        description: app.description,
-        iconUrl: app.iconUrl,
-        tags: app.tags,
-        subdomain: app.subdomain,
-        enabled: app.enabled,
-        sortOrder: index,
-        createdAt: now,
-        updatedAt: now,
-      })),
-    );
+    const rows = await tx
+      .insert(schema.gcCustomApps)
+      .values(
+        apps.map((app, index) => ({
+          id: app.id,
+          name: app.name,
+          description: app.description,
+          iconUrl: app.iconUrl,
+          tags: app.tags,
+          subdomain: app.subdomain,
+          enabled: app.enabled,
+          sortOrder: index,
+          createdAt: now,
+          updatedAt: now,
+        })),
+      )
+      .returning();
+
+    // RETURNING order is unspecified; keep the same order as listCustomApps.
+    return rows
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+      .map(mapCustomAppRow);
   });
-
-  return listCustomApps({ includeDisabled: true });
 };
 
 export const parseAndValidateCustomAppsBody = (

--- a/utils/customApps.ts
+++ b/utils/customApps.ts
@@ -1,0 +1,260 @@
+import { Role } from "~/types/types";
+
+/**
+ * Visibility for custom app cards on the homepage grid.
+ * Hardcoded to Member for now (no per-app role UI). May become configurable later.
+ */
+export const CUSTOM_APP_MIN_ROLE = Role.Member;
+
+export const CUSTOM_APPS_MAX = 20;
+export const CUSTOM_APP_NAME_MAX = 80;
+export const CUSTOM_APP_DESCRIPTION_MAX = 280;
+export const CUSTOM_APP_TAG_MAX_COUNT = 8;
+export const CUSTOM_APP_TAG_MAX_LENGTH = 32;
+export const CUSTOM_APP_ID_MAX = 64;
+export const CUSTOM_APP_SUBDOMAIN_MAX = 63;
+
+export const CUSTOM_APP_SUBDOMAIN_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const CUSTOM_APP_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export type CustomApp = {
+  id: string;
+  name: string;
+  description: string;
+  iconUrl: string;
+  tags: string[];
+  subdomain: string;
+  enabled: boolean;
+  sortOrder: number;
+};
+
+export type CustomAppInput = Omit<CustomApp, "sortOrder"> & {
+  sortOrder?: number;
+};
+
+export const emptyCustomApps = (): CustomApp[] => [];
+
+/** Absolute http(s) URLs and root-relative paths are allowed; empty is not. */
+export const isValidCustomAppIconUrl = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("/")) return true;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const isValidCustomAppSubdomain = (value: string): boolean => {
+  const trimmed = value.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.length <= CUSTOM_APP_SUBDOMAIN_MAX &&
+    CUSTOM_APP_SUBDOMAIN_PATTERN.test(trimmed)
+  );
+};
+
+export const isValidCustomAppId = (value: string): boolean => {
+  const trimmed = value.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.length <= CUSTOM_APP_ID_MAX &&
+    CUSTOM_APP_ID_PATTERN.test(trimmed)
+  );
+};
+
+export const slugifyCustomAppId = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, CUSTOM_APP_ID_MAX);
+
+const isNonEmptyString = (value: unknown, max: number): value is string =>
+  typeof value === "string" &&
+  value.trim().length > 0 &&
+  value.trim().length <= max;
+
+const normalizeTags = (tags: unknown): string[] | null => {
+  if (!Array.isArray(tags)) return null;
+  if (tags.length > CUSTOM_APP_TAG_MAX_COUNT) return null;
+  const normalized: string[] = [];
+  for (const tag of tags) {
+    if (typeof tag !== "string") return null;
+    const trimmed = tag.trim();
+    if (!trimmed || trimmed.length > CUSTOM_APP_TAG_MAX_LENGTH) return null;
+    normalized.push(trimmed);
+  }
+  return normalized;
+};
+
+const ALLOWED_KEYS = new Set([
+  "id",
+  "name",
+  "description",
+  "iconUrl",
+  "tags",
+  "subdomain",
+  "enabled",
+  "sortOrder",
+]);
+
+export type CustomAppValidationError = {
+  index: number;
+  message: string;
+};
+
+export type CustomAppsValidationResult =
+  | { ok: true; apps: CustomApp[] }
+  | { ok: false; errors: CustomAppValidationError[] };
+
+/**
+ * Validates and normalizes a full custom-apps payload for PUT replace.
+ * Assigns sortOrder from array index when omitted.
+ */
+export const validateCustomAppsPayload = (
+  apps: unknown,
+): CustomAppsValidationResult => {
+  if (!Array.isArray(apps)) {
+    return {
+      ok: false,
+      errors: [{ index: -1, message: "apps must be an array" }],
+    };
+  }
+  if (apps.length > CUSTOM_APPS_MAX) {
+    return {
+      ok: false,
+      errors: [
+        {
+          index: -1,
+          message: `at most ${CUSTOM_APPS_MAX} custom apps are allowed`,
+        },
+      ],
+    };
+  }
+
+  const errors: CustomAppValidationError[] = [];
+  const normalized: CustomApp[] = [];
+  const seenIds = new Set<string>();
+  const seenSubdomains = new Set<string>();
+
+  apps.forEach((raw, index) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      errors.push({ index, message: "app must be an object" });
+      return;
+    }
+
+    const record = raw as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (!ALLOWED_KEYS.has(key)) {
+        errors.push({ index, message: `unknown field: ${key}` });
+      }
+    }
+
+    const id = typeof record.id === "string" ? record.id.trim() : "";
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const description =
+      typeof record.description === "string" ? record.description.trim() : "";
+    const iconUrl =
+      typeof record.iconUrl === "string" ? record.iconUrl.trim() : "";
+    const subdomain =
+      typeof record.subdomain === "string" ? record.subdomain.trim() : "";
+    const enabled = record.enabled;
+    const tags = normalizeTags(record.tags);
+
+    if (!isValidCustomAppId(id)) {
+      errors.push({
+        index,
+        message: "id must be a non-empty slug ([a-z0-9-]+)",
+      });
+    } else if (seenIds.has(id)) {
+      errors.push({ index, message: `duplicate id: ${id}` });
+    } else {
+      seenIds.add(id);
+    }
+
+    if (!isNonEmptyString(name, CUSTOM_APP_NAME_MAX)) {
+      errors.push({
+        index,
+        message: `name is required (max ${CUSTOM_APP_NAME_MAX} chars)`,
+      });
+    }
+
+    if (!isNonEmptyString(description, CUSTOM_APP_DESCRIPTION_MAX)) {
+      errors.push({
+        index,
+        message: `description is required (max ${CUSTOM_APP_DESCRIPTION_MAX} chars)`,
+      });
+    }
+
+    if (!isValidCustomAppIconUrl(iconUrl)) {
+      errors.push({
+        index,
+        message: "iconUrl must be http(s) or a root-relative path",
+      });
+    }
+
+    if (tags === null) {
+      errors.push({
+        index,
+        message: `tags must be a string[] (max ${CUSTOM_APP_TAG_MAX_COUNT}, each max ${CUSTOM_APP_TAG_MAX_LENGTH} chars)`,
+      });
+    }
+
+    if (!isValidCustomAppSubdomain(subdomain)) {
+      errors.push({
+        index,
+        message: "subdomain must match [a-z0-9-]+ (no dots)",
+      });
+    } else if (seenSubdomains.has(subdomain)) {
+      errors.push({ index, message: `duplicate subdomain: ${subdomain}` });
+    } else {
+      seenSubdomains.add(subdomain);
+    }
+
+    if (typeof enabled !== "boolean") {
+      errors.push({ index, message: "enabled must be a boolean" });
+    }
+
+    if (
+      record.sortOrder !== undefined &&
+      (typeof record.sortOrder !== "number" ||
+        !Number.isInteger(record.sortOrder))
+    ) {
+      errors.push({ index, message: "sortOrder must be an integer" });
+    }
+
+    if (errors.some((error) => error.index === index)) return;
+
+    normalized.push({
+      id,
+      name,
+      description,
+      iconUrl,
+      tags: tags ?? [],
+      subdomain,
+      enabled: enabled as boolean,
+      sortOrder:
+        typeof record.sortOrder === "number" &&
+        Number.isInteger(record.sortOrder)
+          ? record.sortOrder
+          : index,
+    });
+  });
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    apps: normalized.map((app, index) => ({ ...app, sortOrder: index })),
+  };
+};
+
+export const buildCustomAppUrl = (
+  subdomain: string,
+  communityName: string,
+  domain: string,
+): string => `https://${subdomain}.${communityName}.${domain}`;


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-landing-page/issues/96.

## Screenshots

n/a

## What I changed and why

- Added `gc_custom_apps` Drizzle schema + migration.
- Added shared `CustomApp` types/validation helpers and server list/replace utilities for the upcoming admin API and homepage grid.

## How I convinced myself this is right

Plan validation, and following existing Drizzle / migration conventions.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5 implementation based on plan. I didn't spot anything that needed fixing.