### PR TITLE
Merge custom apps into the homepage `ServicesGrid`

### DIFF
--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -2,26 +2,37 @@
 import { computed } from "vue";
 import { useI18n, useRuntimeConfig, useUserSession } from "#imports";
 import { Smile } from "lucide-vue-next";
+import { useCustomApps } from "~/composables/useCustomApps";
 import { Role, type User } from "~/types/types";
+import { buildCustomAppUrl, CUSTOM_APP_MIN_ROLE } from "~/utils/customApps";
+
+type ServiceCard = {
+  key: string;
+  name: string;
+  url: string;
+  icon: string;
+  iconUrl?: string;
+  description?: string;
+  tags: string[];
+  /** Built-in tags are i18n-mapped; custom app tags are freeform. */
+  translateTags: boolean;
+};
 
 const config = useRuntimeConfig();
 const communityName = config.public.communityName;
 const domain = config.public.domain;
 const { t } = useI18n();
 const { user } = useUserSession();
+const { apps: customApps } = useCustomApps();
 
 const availableServices = computed(() => {
-  const services: Array<{
-    name: string;
-    url: string;
-    icon: string;
-    tags: string[];
-  }> = [];
+  const services: ServiceCard[] = [];
   const typedUser = user.value as User | undefined;
   const userRole = typedUser?.userRole ?? Role.SignedIn;
 
   if (config.public.explorerEnabled && userRole >= Role.SignedIn) {
     services.push({
+      key: "explorer",
       name: "Explorer",
       url: `https://explorer.${communityName}.${domain}`,
       icon: "explorer",
@@ -31,34 +42,58 @@ const availableServices = computed(() => {
         "Wildlife Explorer",
         "Media Galleries",
       ],
+      translateTags: true,
     });
   }
 
   if (config.public.supersetEnabled && userRole >= Role.Guest) {
     services.push({
+      key: "superset",
       name: "Superset",
       url: `https://superset.${communityName}.${domain}`,
       icon: "superset",
       tags: ["Charts", "Analysis", "Visualizations", "Dashboards"],
+      translateTags: true,
     });
   }
 
   if (config.public.windmillEnabled && userRole >= Role.Admin) {
     services.push({
+      key: "windmill",
       name: "Windmill",
       url: `https://windmill.${communityName}.${domain}`,
       icon: "windmill",
       tags: ["Data Flows", "Scheduled Jobs", "Data Apps"],
+      translateTags: true,
     });
   }
 
   if (config.public.filebrowserEnabled && userRole >= Role.Member) {
     services.push({
+      key: "filebrowser",
       name: "Filebrowser",
       url: `https://files.${communityName}.${domain}`,
       icon: "filebrowser",
       tags: ["Files", "Raw Data", "Archives"],
+      translateTags: true,
     });
+  }
+
+  // Custom apps after built-ins; visibility hardcoded to Member (may become
+  // configurable later via CUSTOM_APP_MIN_ROLE).
+  if (userRole >= CUSTOM_APP_MIN_ROLE) {
+    for (const app of customApps.value) {
+      services.push({
+        key: `custom-${app.id}`,
+        name: app.name,
+        url: buildCustomAppUrl(app.subdomain, communityName, domain),
+        icon: "custom",
+        iconUrl: app.iconUrl,
+        description: app.description,
+        tags: app.tags,
+        translateTags: false,
+      });
+    }
   }
 
   return services;
@@ -72,7 +107,9 @@ const openService = (url: string) => {
   }
 };
 
-const getServiceDescription = (serviceName: string) => {
+const getServiceDescription = (service: ServiceCard) => {
+  if (service.description) return service.description;
+
   const descriptions = {
     Superset: t("services.supersetDescription"),
     Windmill: t("services.windmillDescription"),
@@ -80,7 +117,7 @@ const getServiceDescription = (serviceName: string) => {
     Filebrowser: t("services.filebrowserDescription"),
   };
   return (
-    descriptions[serviceName as keyof typeof descriptions] ||
+    descriptions[service.name as keyof typeof descriptions] ||
     t("services.communityService")
   );
 };
@@ -104,6 +141,9 @@ const translateTag = (tag: string) => {
   };
   return tagMap[tag] || tag;
 };
+
+const displayTag = (service: ServiceCard, tag: string) =>
+  service.translateTags ? translateTag(tag) : tag;
 </script>
 
 <template>
@@ -114,7 +154,7 @@ const translateTag = (tag: string) => {
     >
       <div
         v-for="service in availableServices"
-        :key="service.name"
+        :key="service.key"
         class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-violet-200 dark:border-violet-900 bg-gradient-to-br from-violet-50 to-violet-100 dark:from-violet-950/40 dark:to-violet-900/40 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
         @click="openService(service.url)"
       >
@@ -159,6 +199,16 @@ const translateTag = (tag: string) => {
               class="h-[67px] w-[67px] object-contain"
             />
           </div>
+          <div
+            v-else-if="service.icon === 'custom' && service.iconUrl"
+            class="flex h-[67px] w-[67px] items-center justify-center"
+          >
+            <img
+              :src="service.iconUrl"
+              :alt="service.name"
+              class="h-[67px] w-[67px] object-contain"
+            />
+          </div>
         </div>
 
         <h3
@@ -170,7 +220,7 @@ const translateTag = (tag: string) => {
         <p
           class="mb-4 min-h-[3rem] text-center text-sm text-gray-600 dark:text-dusk-400"
         >
-          {{ getServiceDescription(service.name) }}
+          {{ getServiceDescription(service) }}
         </p>
 
         <div class="flex flex-wrap justify-center gap-2">
@@ -179,7 +229,7 @@ const translateTag = (tag: string) => {
             :key="tag"
             class="rounded-full border border-gray-200 dark:border-dusk-700 bg-white dark:bg-dusk-800 px-3 py-1 text-xs font-medium text-gray-700 dark:text-dusk-300"
           >
-            {{ translateTag(tag) }}
+            {{ displayTag(service, tag) }}
           </span>
         </div>
       </div>

--- a/composables/useCustomApps.ts
+++ b/composables/useCustomApps.ts
@@ -1,0 +1,44 @@
+import { computed } from "vue";
+import { useFetch, useUserSession } from "#imports";
+import { Role, type User } from "~/types/types";
+import {
+  CUSTOM_APP_MIN_ROLE,
+  emptyCustomApps,
+  type CustomApp,
+} from "~/utils/customApps";
+
+interface CustomAppsResponse {
+  success: boolean;
+  apps: CustomApp[];
+}
+
+/**
+ * Fetches enabled custom apps for the homepage grid.
+ * Skips the request below CUSTOM_APP_MIN_ROLE (Member); that gate is hardcoded
+ * for now and may become configurable later.
+ */
+export const useCustomApps = () => {
+  const { user } = useUserSession();
+
+  const userRole = computed(
+    () => (user.value as User | undefined)?.userRole ?? Role.SignedIn,
+  );
+
+  const canViewCustomApps = computed(
+    () => userRole.value >= CUSTOM_APP_MIN_ROLE,
+  );
+
+  const { data, pending, error, refresh } = useFetch<CustomAppsResponse>(
+    () => (canViewCustomApps.value ? "/api/custom_apps/custom-apps" : null),
+    {
+      key: "gc-custom-apps",
+      default: () => ({ success: true, apps: emptyCustomApps() }),
+    },
+  );
+
+  const apps = computed(() =>
+    canViewCustomApps.value ? (data.value?.apps ?? emptyCustomApps()) : [],
+  );
+
+  return { apps, pending, error, refresh, canViewCustomApps };
+};

--- a/composables/useCustomApps.ts
+++ b/composables/useCustomApps.ts
@@ -1,10 +1,6 @@
 import { computed } from "vue";
 import { useFetch, useUserSession } from "#imports";
-import {
-  Role,
-  type CustomAppsResponse,
-  type User,
-} from "~/types/types";
+import { Role, type CustomAppsResponse, type User } from "~/types/types";
 import { CUSTOM_APP_MIN_ROLE, emptyCustomApps } from "~/utils/customApps";
 
 /**

--- a/composables/useCustomApps.ts
+++ b/composables/useCustomApps.ts
@@ -1,16 +1,11 @@
 import { computed } from "vue";
 import { useFetch, useUserSession } from "#imports";
-import { Role, type User } from "~/types/types";
 import {
-  CUSTOM_APP_MIN_ROLE,
-  emptyCustomApps,
-  type CustomApp,
-} from "~/utils/customApps";
-
-interface CustomAppsResponse {
-  success: boolean;
-  apps: CustomApp[];
-}
+  Role,
+  type CustomAppsResponse,
+  type User,
+} from "~/types/types";
+import { CUSTOM_APP_MIN_ROLE, emptyCustomApps } from "~/utils/customApps";
 
 /**
  * Fetches enabled custom apps for the homepage grid.

--- a/types/types.ts
+++ b/types/types.ts
@@ -62,5 +62,22 @@ export interface RolesResponse {
   roles: UserRole[];
 }
 
+// Custom Apps
+export type CustomApp = {
+  id: string;
+  name: string;
+  description: string;
+  iconUrl: string;
+  tags: string[];
+  subdomain: string;
+  enabled: boolean;
+  sortOrder: number;
+};
+
+export interface CustomAppsResponse {
+  success: boolean;
+  apps: CustomApp[];
+}
+
 // I18n Types
 export type SupportedLocale = "en" | "pt" | "es" | "nl";

--- a/utils/customApps.ts
+++ b/utils/customApps.ts
@@ -1,4 +1,6 @@
-import { Role } from "~/types/types";
+import { Role, type CustomApp } from "~/types/types";
+
+export type { CustomApp };
 
 /**
  * Visibility for custom app cards on the homepage grid.
@@ -16,17 +18,6 @@ export const CUSTOM_APP_SUBDOMAIN_MAX = 63;
 
 export const CUSTOM_APP_SUBDOMAIN_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 export const CUSTOM_APP_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-export type CustomApp = {
-  id: string;
-  name: string;
-  description: string;
-  iconUrl: string;
-  tags: string[];
-  subdomain: string;
-  enabled: boolean;
-  sortOrder: number;
-};
 
 export type CustomAppInput = Omit<CustomApp, "sortOrder"> & {
   sortOrder?: number;


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-landing-page/issues/99.

## Screenshots

I don't have any to provide, as we still lack the ability to actually _define_ a new custom app (next PR).

On that note, I might have a final PR to do style tweaks after everything has come together.

## What I changed and why

- Added `useCustomApps` composable to fetch enabled custom apps for Member+.
- Merged those cards into `ServicesGrid` after built-ins, using stored copy/`iconUrl` and subdomain URLs.

## How I convinced myself this is right

The plan!

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5 implementation based on plan. Only a small fix to organization of types.