### PR TITLE
Support authStrategy=none with a local Admin session (quality-of-life DX improvement) 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
 # Required: Community Configuration
 NUXT_PUBLIC_COMMUNITY_NAME=
 
-# required: Auth0 Configuration (enables authentication)
+# ==========================================
+# Authentication
+# ==========================================
+# auth0 — Auth0 login + RBAC 
+# none  — skip Auth0, seeds a local Admin session 
+NUXT_PUBLIC_AUTH_STRATEGY="auth0"
+
+# Auth0 credentials (required when NUXT_PUBLIC_AUTH_STRATEGY=auth0)
 NUXT_OAUTH_AUTH0_CLIENT_SECRET=
 NUXT_OAUTH_AUTH0_CLIENT_ID=
 NUXT_OAUTH_AUTH0_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 
 ## Authentication
 
+Set `NUXT_PUBLIC_AUTH_STRATEGY` to `auth0` or `none`. See [docs/auth.md](docs/auth.md) for RBAC details.
+
+- **auth0** — Auth0 login + RBAC (production, or local work on auth). Requires the Auth0 env vars below.
+- **none** — Skip Auth0 and seed a local Admin session (recommended for everyday local/dev).
+
 ### Auth0 Setup
 
 1. **Create Auth0 Application**
@@ -62,9 +67,12 @@ docker run --env-file=.env -it -p 8080:8080 gc-landing-page:latest
 
 2. **Configure Environment Variables**
    ```bash
-   NUXT_AUTH0_DOMAIN=your-tenant.auth0.com
-   NUXT_AUTH0_CLIENT_ID=your-client-id
+   NUXT_PUBLIC_AUTH_STRATEGY=auth0
+   NUXT_OAUTH_AUTH0_DOMAIN=your-tenant.auth0.com
+   NUXT_OAUTH_AUTH0_CLIENT_ID=your-client-id
+   NUXT_OAUTH_AUTH0_CLIENT_SECRET=your-client-secret
    ```
+
 
 ## Service Configuration Details
 

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -7,13 +7,7 @@ import { useThemeSettings } from "@/composables/useThemeSettings";
 import { Workflow } from "lucide-vue-next";
 
 const props = defineProps<{
-  isAuth0Configured: boolean;
-  loggedIn: boolean;
   shouldShowApp: boolean;
-}>();
-
-defineEmits<{
-  login: [];
 }>();
 
 const config = useRuntimeConfig();

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -24,12 +24,11 @@ interface User {
 
 const config = useRuntimeConfig();
 const communityName = config.public.communityName;
+const isAuth0 = config.public.authStrategy === "auth0";
 const { t } = useI18n();
 
 // Auth state using nuxt-auth-utils
 const { loggedIn, user } = useUserSession();
-
-const isAuth0Configured = config.public.auth0Enabled;
 
 const isAdmin = computed(() => {
   const typedUser = user.value as User;
@@ -101,7 +100,7 @@ const { login, logout } = useAuthActions();
       <!-- Right: Action buttons -->
       <div class="flex items-center space-x-3 ml-auto mr-2">
         <!-- Auth controls -->
-        <div v-if="isAuth0Configured && !loggedIn">
+        <div v-if="isAuth0 && !loggedIn">
           <button
             @click="login"
             class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors text-sm font-medium"
@@ -111,10 +110,7 @@ const { login, logout } = useAuthActions();
         </div>
 
         <!-- Auth controls when logged in -->
-        <div
-          v-if="isAuth0Configured && loggedIn"
-          class="flex items-center space-x-3"
-        >
+        <div v-if="isAuth0 && loggedIn" class="flex items-center space-x-3">
           <button
             @click="logout"
             class="text-gray-600 hover:text-gray-900 dark:text-dusk-400 dark:hover:text-dusk-100 transition-colors text-sm max-[1200px]:text-xs"
@@ -124,10 +120,7 @@ const { login, logout } = useAuthActions();
         </div>
 
         <!-- User Management -->
-        <div
-          v-if="isAuth0Configured && loggedIn && isAdmin"
-          class="relative group"
-        >
+        <div v-if="loggedIn && isAdmin" class="relative group">
           <NuxtLink
             to="/admin/users"
             class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-dusk-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-800"
@@ -143,10 +136,7 @@ const { login, logout } = useAuthActions();
         </div>
 
         <!-- Theme Settings -->
-        <div
-          v-if="isAuth0Configured && loggedIn && isAdmin"
-          class="relative group"
-        >
+        <div v-if="loggedIn && isAdmin" class="relative group">
           <NuxtLink
             to="/admin/theme"
             class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-dusk-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-800"
@@ -193,7 +183,7 @@ const { login, logout } = useAuthActions();
       <!-- Right: User Icon and Hamburger Menu -->
       <div class="flex items-center space-x-2">
         <!-- User Icon with Checkmark (if logged in) -->
-        <div v-if="isAuth0Configured && loggedIn" class="relative">
+        <div v-if="loggedIn" class="relative">
           <div
             class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 border-2 border-green-500 flex items-center justify-center relative"
           >
@@ -217,7 +207,7 @@ const { login, logout } = useAuthActions();
 
     <!-- Mobile Menu Dropdown -->
     <div
-      v-if="mobileMenuOpen && isAuth0Configured && loggedIn"
+      v-if="mobileMenuOpen && loggedIn"
       class="hidden max-[1000px]:block mt-4 p-4 bg-white dark:bg-dusk-800 rounded-lg border border-violet-200 dark:border-dusk-700 shadow-lg"
     >
       <!-- Welcome Message -->
@@ -283,6 +273,7 @@ const { login, logout } = useAuthActions();
 
       <!-- Sign Out -->
       <button
+        v-if="isAuth0"
         @click="
           logout();
           mobileMenuOpen = false;
@@ -297,10 +288,7 @@ const { login, logout } = useAuthActions();
     </div>
 
     <!-- Mobile Sign In Button (if not logged in) -->
-    <div
-      v-if="isAuth0Configured && !loggedIn"
-      class="hidden max-[1000px]:block mt-4"
-    >
+    <div v-if="isAuth0 && !loggedIn" class="hidden max-[1000px]:block mt-4">
       <button
         @click="login"
         class="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors text-sm font-medium"

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -182,7 +182,7 @@ curl --request GET \
 2. **"Management API configuration missing"**: Verify environment variables are set
 3. **"Failed to fetch user roles"**: Check Management API authorization and scopes
 4. **"Windmill not visible"**: Verify user has Admin role assigned
-5. **"Auth0 not working"**: Check if `NUXT_PUBLIC_AUTH0_ENABLED` is set to `true`
+5. **"Auth0 not working"**: Check if `NUXT_PUBLIC_AUTH_STRATEGY` is set to `auth0`
 6. **"Failed to remove user"**: Ensure the application is granted the `delete:users` scope on the Auth0 Management API.
 
 ### RBAC not working despite correct Auth0 configuration
@@ -193,4 +193,4 @@ If RBAC is not working despite correct Auth0 configuration, try restarting the a
 
 - **Windmill not showing**: Ensure user has "Admin" role assigned
 - **No services showing**: Check service availability flags in environment variables
-- **Authentication not working**: Verify Auth0 configuration and `auth0Enabled` flag
+- **Authentication not working**: Verify Auth0 configuration and that `NUXT_PUBLIC_AUTH_STRATEGY` is `auth0`

--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -1,10 +1,17 @@
-import { defineNuxtRouteMiddleware, navigateTo } from "#imports";
+import {
+  defineNuxtRouteMiddleware,
+  navigateTo,
+  useRuntimeConfig,
+} from "#imports";
 import type { User } from "~/types/types";
 import { Role } from "~/types/types";
 import { createError } from "h3";
 // Following example: https://github.com/atinux/atidone/blob/main/app/middleware/auth.ts
 export default defineNuxtRouteMiddleware(async (to) => {
   const { loggedIn, user } = useUserSession();
+  const {
+    public: { authStrategy },
+  } = useRuntimeConfig();
   const router = useRouter();
 
   // Handle logout flow
@@ -13,6 +20,11 @@ export default defineNuxtRouteMiddleware(async (to) => {
     sessionCookie.value = null;
 
     return navigateTo("/");
+  }
+
+  if (authStrategy === "none") {
+    if (to.path === "/login") return router.push("/");
+    return;
   }
 
   // In order to redirect the user back to the page they were on when unauthenticated, we need to store the redirect url in session storage
@@ -30,7 +42,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
   }
 
-  if (!loggedIn.value && to.path !== "/login") {
+  if (authStrategy === "auth0" && !loggedIn.value && to.path !== "/login") {
     return router.push("/login");
   }
 
@@ -39,7 +51,11 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   // Admin route protection
-  if (loggedIn.value && to.path.startsWith("/admin")) {
+  if (
+    authStrategy === "auth0" &&
+    loggedIn.value &&
+    to.path.startsWith("/admin")
+  ) {
     const userRole = (user.value as User)?.userRole;
 
     if (!userRole || userRole < Role.Admin) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,7 +59,7 @@ export default defineNuxtConfig({
       communityName: "demo",
       domain: "guardianconnector.net",
       baseUrl: "http://localhost:8080",
-      auth0Enabled: true,
+      authStrategy: "auth0",
       // Service availability flags
       supersetEnabled: false,
       windmillEnabled: false,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,19 +2,16 @@
 import { useUserSession, useRuntimeConfig, useHead } from "#imports";
 import { computed } from "vue";
 import HomePage from "@/components/HomePage.vue";
-import { useAuthActions } from "@/composables/useAuth";
 
-const config = useRuntimeConfig();
+const {
+  public: { authStrategy },
+} = useRuntimeConfig();
 const { t } = useI18n();
 const { loggedIn } = useUserSession();
 
-const isAuth0Configured = config.public.auth0Enabled;
-
 const shouldShowApp = computed(() => {
-  return isAuth0Configured ? loggedIn.value : true;
+  return authStrategy === "auth0" ? loggedIn.value : true;
 });
-
-const { login } = useAuthActions();
 
 useHead({
   title: t("app.title"),
@@ -22,10 +19,5 @@ useHead({
 </script>
 
 <template>
-  <HomePage
-    :is-auth0-configured="isAuth0Configured"
-    :logged-in="loggedIn"
-    :should-show-app="shouldShowApp"
-    @login="login"
-  />
+  <HomePage :should-show-app="shouldShowApp" />
 </template>

--- a/server/middleware/local-auth.ts
+++ b/server/middleware/local-auth.ts
@@ -1,0 +1,31 @@
+import { Role, type User } from "~/types/types";
+
+/**
+ * When NUXT_PUBLIC_AUTH_STRATEGY=none, ensure every request has a local
+ * Admin session so route/API RBAC works without Auth0.
+ */
+export default defineEventHandler(async (event) => {
+  const {
+    public: { authStrategy },
+  } = useRuntimeConfig();
+  if (authStrategy !== "none") return;
+
+  const session = await getUserSession(event);
+  const typedUser = session.user as User | undefined;
+  if (typedUser?.userRole === Role.Admin) return;
+
+  await setUserSession(event, {
+    user: {
+      auth0: "local-dev@localhost",
+      roles: [
+        {
+          id: "local-admin",
+          name: "Admin",
+          description: "Local development admin (authStrategy=none)",
+        },
+      ],
+      userRole: Role.Admin,
+    },
+    loggedInAt: Date.now(),
+  });
+});

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -9,14 +9,21 @@ import type { User } from "~/types/types";
  * @param {H3Event} event - Nuxt server event.
  * @param {Role} minRole - Minimum required role.
  * @returns {Promise<User>} The authenticated user from session.
- * @throws {Error} 401 when no session user exists.
+ * @throws {Error} 401 when no session user exists (skipped when authStrategy is "none").
  * @throws {Error} 403 when user is authenticated but below minRole.
  */
 const requireMinRoleSession = async (
   event: H3Event,
   minRole: Role,
 ): Promise<User> => {
+  const {
+    public: { authStrategy },
+  } = useRuntimeConfig();
   const session = await getUserSession(event);
+
+  if (authStrategy === "none") {
+    return session.user as User;
+  }
 
   if (!session.user) {
     throw createError({


### PR DESCRIPTION
## Goal

To support the same DX improvement as https://github.com/ConservationMetrics/gc-explorer/pull/559 did for GC Explorer.

## Screenshots

n/a

## What I changed and why

- Similar approach to set `server/middleware/local-auth.ts` and bypass in `middleware/oauth.global.ts`
- Here, we did have to do some additional work to replace an `auth0Enabled` boolean to match the Explorer convention of checking for `authStrategy` (`auth0` | `none`).
- 

## How I convinced myself this is right

Trying locally.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.6 did the implementation based on reviewing the code changes from https://github.com/ConservationMetrics/gc-explorer/pull/559. Then I made changes, mostly to verbose comments.