### PR TITLE
Bugfixes after merging of Custom Apps epic

### DIFF
--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -153,10 +153,7 @@ const { login, logout } = useAuthActions();
         </div>
 
         <!-- Custom Apps -->
-        <div
-          v-if="isAuth0Configured && loggedIn && isAdmin"
-          class="relative group"
-        >
+        <div v-if="loggedIn && isAdmin" class="relative group">
           <NuxtLink
             to="/admin/apps"
             class="w-10 h-10 rounded-full bg-white dark:bg-dusk-700 flex items-center justify-center hover:bg-gray-50 dark:hover:bg-dusk-600 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 dark:focus:ring-offset-dusk-800"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,13 +15,6 @@ export default defineNuxtConfig({
 
   modules: ["nuxt-auth-utils", "@nuxtjs/i18n", "@nuxtjs/tailwindcss"],
 
-  // Let Vite process this package during SSR so its CSS import is handled.
-  vite: {
-    ssr: {
-      noExternal: ["@vojtechlanka/vue-tags-input"],
-    },
-  },
-
   i18n: {
     locales: [
       { code: "en", name: "English", language: "en-US", file: "en.json" },

--- a/pages/admin/apps.vue
+++ b/pages/admin/apps.vue
@@ -32,5 +32,7 @@ useHead({
 </script>
 
 <template>
-  <CustomAppsSettings />
+  <ClientOnly>
+    <CustomAppsSettings />
+  </ClientOnly>
 </template>


### PR DESCRIPTION
## Goal

When deploying `main` to prod, I found two bugs that needed fixing after the merging of https://github.com/ConservationMetrics/gc-landing-page/issues/89:

1. Custom Apps icon in `AppHeader` was still gated behind now-outmoded `isAuth0Configured` boolean (c.f. https://github.com/ConservationMetrics/gc-landing-page/pull/104)
2. The way `vue-tags-input` was wired in was breaking production. In alignment with Explorer, we are wrapping the entire page featuring this component in `<ClientOnly>` which is perfectly f ine behavior as nothing on the page needs to be available to SSR.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None