### PR TITLE
Hide Data Sources grid, and improve card width, if Role < Member

### DIFF
--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -25,7 +25,7 @@ const canSeeDataSources = computed(() => {
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-white dark:bg-dusk-900">
+  <div class="flex flex-col bg-white dark:bg-dusk-900">
     <main class="mx-auto mt-10 max-w-7xl px-4 pb-12 pt-0 sm:px-6 lg:px-8">
       <div class="pt-0">
         <div v-if="logoUrl" class="mb-8 flex justify-center">

--- a/components/HomePage.vue
+++ b/components/HomePage.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
-import { useRuntimeConfig } from "#imports";
+import { computed } from "vue";
+import { useRuntimeConfig, useUserSession } from "#imports";
 import HoverTooltip from "@/components/shared/HoverTooltip.vue";
 import ServicesGrid from "@/components/homepage/ServicesGrid.vue";
 import DataSourcesGrid from "@/components/homepage/DataSourcesGrid.vue";
 import { useThemeSettings } from "@/composables/useThemeSettings";
+import { Role, type User } from "~/types/types";
 import { Workflow } from "lucide-vue-next";
 
 const props = defineProps<{
@@ -14,6 +16,12 @@ const config = useRuntimeConfig();
 const communityName = config.public.communityName;
 const { logoUrl } = useThemeSettings();
 const { t } = useI18n();
+const { user } = useUserSession();
+
+const canSeeDataSources = computed(() => {
+  const typedUser = user.value as User | undefined;
+  return (typedUser?.userRole ?? Role.SignedIn) >= Role.Member;
+});
 </script>
 
 <template>
@@ -50,7 +58,7 @@ const { t } = useI18n();
         <ServicesGrid v-if="props.shouldShowApp" />
 
         <div
-          v-if="props.shouldShowApp"
+          v-if="props.shouldShowApp && canSeeDataSources"
           class="relative my-12"
           aria-hidden="true"
         >
@@ -68,7 +76,7 @@ const { t } = useI18n();
           </div>
         </div>
 
-        <DataSourcesGrid v-if="props.shouldShowApp" />
+        <DataSourcesGrid v-if="props.shouldShowApp && canSeeDataSources" />
 
         <div v-if="props.shouldShowApp" class="mb-8 mt-8 text-center">
           <p class="text-sm italic text-gray-600 dark:text-dusk-400">

--- a/components/homepage/ServicesGrid.vue
+++ b/components/homepage/ServicesGrid.vue
@@ -155,7 +155,7 @@ const displayTag = (service: ServiceCard, tag: string) =>
       <div
         v-for="service in availableServices"
         :key="service.key"
-        class="flex w-full max-w-sm cursor-pointer flex-col rounded-2xl border border-violet-200 dark:border-violet-900 bg-gradient-to-br from-violet-50 to-violet-100 dark:from-violet-950/40 dark:to-violet-900/40 p-6 transition-all duration-200 hover:shadow-lg md:w-[calc(50%-12px)] lg:w-[calc(25%-18px)]"
+        class="flex w-full max-w-[16.5rem] shrink-0 cursor-pointer flex-col rounded-2xl border border-violet-200 dark:border-violet-900 bg-gradient-to-br from-violet-50 to-violet-100 dark:from-violet-950/40 dark:to-violet-900/40 p-6 transition-all duration-200 hover:shadow-lg"
         @click="openService(service.url)"
       >
         <div class="mb-4 flex justify-center">


### PR DESCRIPTION
## Goal

I noticed that when you sign in as Guest / SignedIn role, the Data Sources grid shows, which doesn't really make sense for these roles. And, when you remove that grid, the card sizes were all messed up due to the width calculations. This PR fixes both.

## Screenshots

<img width="1191" height="608" alt="image" src="https://github.com/user-attachments/assets/9c8343d4-6edd-41ec-a490-c35902111bd6" />

_Guest view_


## What I changed and why

- Added `canSeeDataSources` computed and implemented it as a conditional var to render the DataSources grid.
- Set a fixed width for the cards.
- Remove `min-h-screen` from template as it left unnecessary negative space at the bottom.

## How I convinced myself this is right

Testing in runtime.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Auto mode did this via my prompts.